### PR TITLE
Enable dark mode only and simplify admin access

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -8,8 +8,8 @@
   <style>
     body {
       font-family: sans-serif;
-      background-color: #f4f4f4;
-      color: #333;
+      background-color: var(--bg);
+      color: var(--fg);
     }
     .container {
       max-width: 900px; /* Augmenté pour plus d'espace */
@@ -17,8 +17,8 @@
       padding: 1rem;
     }
     .header {
-      background: #333;
-      color: white;
+      background: var(--card-bg);
+      color: var(--fg);
       padding: 1rem 0;
     }
     .header__inner {
@@ -27,13 +27,13 @@
       align-items: center;
     }
     .logo {
-      color: white;
+      color: var(--fg);
       text-decoration: none;
       font-size: 1.5rem;
       font-weight: bold;
     }
     .nav a {
-      color: white;
+      color: var(--fg);
       text-decoration: none;
       margin-left: 1rem;
     }
@@ -41,22 +41,22 @@
       max-width: 800px;
       margin: 2rem auto;
       padding: 2rem;
-      background: white;
+      background: var(--card-bg);
       border-radius: 8px;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+      box-shadow: 0 2px 10px rgba(0,0,0,0.4);
     }
     .password-section {
       margin-bottom: 2rem;
       padding: 1.5rem;
-      background-color: #f9f9f9;
+      background-color: var(--card-bg-alt);
       border-radius: 4px;
-      border: 1px solid #eee;
+      border: 1px solid var(--border-color);
     }
     .password-section input[type="password"], .password-section button {
       padding: 10px;
       margin-right: 10px;
       border-radius: 4px;
-      border: 1px solid #ddd;
+      border: 1px solid var(--border-color);
     }
     .password-section button {
       background: #5cb85c;
@@ -70,11 +70,11 @@
       margin-top: 2rem;
     }
     .order-item {
-      padding: 1.5rem; /* Augmenté */
-      border: 1px solid #ddd;
+      padding: 1.5rem;
+      border: 1px solid var(--border-color);
       border-radius: 4px;
-      margin-bottom: 1.5rem; /* Augmenté */
-      background-color: #fff;
+      margin-bottom: 1.5rem;
+      background-color: var(--card-bg-alt);
     }
     .order-header {
       display: flex;
@@ -93,12 +93,14 @@
       font-weight: bold;
     }
     .status-select, .notes-input {
-      width: calc(100% - 22px); /* Ajusté pour padding/border */
+      width: calc(100% - 22px);
       padding: 10px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--border-color);
       margin-top: 0.25rem;
       margin-bottom: 0.75rem;
+      background: var(--card-bg);
+      color: var(--fg);
     }
     .notes-input {
       min-height: 60px; /* Hauteur pour les notes */
@@ -120,12 +122,14 @@
       background: #1ed760;
     }
     .search-box {
-      width: calc(100% - 24px); /* Ajusté */
+      width: calc(100% - 24px);
       padding: 12px;
       margin-bottom: 1rem;
-      border: 1px solid #ddd;
+      border: 1px solid var(--border-color);
       border-radius: 4px;
       font-size: 1rem;
+      background: var(--card-bg);
+      color: var(--fg);
     }
      #loadingIndicator, #errorMessage {
         text-align: center;

--- a/css/style.css
+++ b/css/style.css
@@ -18,55 +18,7 @@
   --hover-bg: rgba(255, 255, 255, 0.05);
 }
 
-/* Light Theme */
-.light-theme {
-  --bg: #f5f5f5;
-  --fg: #333333;
-  --card-bg: #ffffff;
-  --card-bg-alt: #f8f9fa;
-  --shadow-color: rgba(0, 0, 0, 0.1);
-  --border-color: rgba(0, 0, 0, 0.1);
-  --hover-bg: rgba(0, 0, 0, 0.05);
-}
 
-/* Theme Toggle Button */
-.theme-toggle {
-  position: fixed;
-  bottom: 20px;
-  left: 20px;
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  background: var(--card-bg);
-  border: 2px solid var(--border-color);
-  color: var(--fg);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  transition: all var(--transition);
-  box-shadow: 0 4px 12px var(--shadow-color);
-}
-
-.theme-toggle:hover {
-  transform: scale(1.1);
-  background: var(--hover-bg);
-}
-
-.theme-toggle svg {
-  width: 24px;
-  height: 24px;
-  transition: transform var(--transition);
-}
-
-.light-theme .sun-icon {
-  display: none;
-}
-
-.dark-theme .moon-icon {
-  display: none;
-}
 
 /* Background alternés */
 section.hero   { background: var(--gradient); }
@@ -238,6 +190,11 @@ body::before {
   -webkit-overflow-scrolling: touch;
   scroll-snap-type: x mandatory;
   cursor: grab;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.feature-slider::-webkit-scrollbar {
+  display: none;
 }
 .feature-slider:active {
   cursor: grabbing;
@@ -1710,23 +1667,6 @@ input, textarea, select {
   box-shadow: 0 8px 24px var(--shadow-color);
 }
 
-/* Update chat widget for light theme */
-.light-theme .chat-container {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-}
-
-.light-theme .message.system {
-  background: var(--card-bg-alt);
-}
-
-/* Update form elements for light theme */
-.light-theme input:focus,
-.light-theme textarea:focus,
-.light-theme select:focus {
-  border-color: var(--accent1);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
-}
 
 /* Update scrollbar for both themes */
 ::-webkit-scrollbar {

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
         <a href="#pricing">Offre</a>
         <a href="#how">Comment ça marche</a>
         <a href="#faq">FAQ</a>
+        <a href="admin.html">Admin</a>
       </nav>
       <a href="#commande" class="btn btn--sm">Commander</a>
     </div>
@@ -471,23 +472,6 @@
     </div>
   </section>
 
-  <!-- Theme Toggle Button -->
-  <button id="theme-toggle" class="theme-toggle" aria-label="Changer le thème">
-    <svg class="sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="5"/>
-      <line x1="12" y1="1" x2="12" y2="3"/>
-      <line x1="12" y1="21" x2="12" y2="23"/>
-      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-      <line x1="1" y1="12" x2="3" y2="12"/>
-      <line x1="21" y1="12" x2="23" y2="12"/>
-      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-    </svg>
-    <svg class="moon-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-    </svg>
-  </button>
 
   <div class="divider divider--slant"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -189,33 +189,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     window.updateProgressBar = updateProgressBar;
 
-    // Theme Toggle
-    const themeToggle = document.getElementById('theme-toggle');
-    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-    
-    if (themeToggle) {
-        // Vérifier le thème sauvegardé
-        const savedTheme = localStorage.getItem('theme');
-        if (savedTheme) {
-            document.body.classList.toggle('light-theme', savedTheme === 'light');
-        } else {
-            document.body.classList.toggle('light-theme', !prefersDarkScheme.matches);
-        }
-
-        // Gérer le changement de thème
-        themeToggle.addEventListener('click', () => {
-            document.body.classList.toggle('light-theme');
-            const isLight = document.body.classList.contains('light-theme');
-            localStorage.setItem('theme', isLight ? 'light' : 'dark');
-        });
-
-        // Écouter les changements de préférence système
-        prefersDarkScheme.addEventListener('change', (e) => {
-            if (!localStorage.getItem('theme')) {
-                document.body.classList.toggle('light-theme', !e.matches);
-            }
-        });
-    }
 
     // Suivi de commande
     const trackSection = document.getElementById('order-tracking');

--- a/tracking.html
+++ b/tracking.html
@@ -11,18 +11,20 @@
       max-width: 500px;
       margin: 2rem auto;
       padding: 2rem;
-      background: white;
+      background: var(--card-bg);
       border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      box-shadow: 0 2px 4px rgba(0,0,0,0.4);
     }
 
     .tracking-form input {
       width: 100%;
       padding: 12px;
       margin: 8px 0;
-      border: 1px solid #ddd;
+      border: 1px solid var(--border-color);
       border-radius: 4px;
       font-size: 16px;
+      background: var(--card-bg-alt);
+      color: var(--fg);
     }
 
     .tracking-result {
@@ -30,6 +32,7 @@
       padding: 1.5rem;
       border-radius: 8px;
       display: none;
+      background: var(--card-bg-alt);
     }
 
     .tracking-result.active {
@@ -132,6 +135,7 @@
         <a href="index.html#pricing">Tarifs</a>
         <a href="index.html#how">Comment ça marche</a>
         <a href="index.html#faq">FAQ</a>
+        <a href="admin.html">Admin</a>
       </nav>
       <a href="index.html#commande" class="btn btn--sm">Commander</a>
     </div>


### PR DESCRIPTION
## Summary
- remove theme toggle to always use dark mode
- hide feature slider scrollbar for smoother drag
- add admin link to navigation
- restyle admin and tracking pages using dark theme variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c1b4b91c832e816207b4400a9c9d