### PR TITLE
Add dedicated admin login page

### DIFF
--- a/admin-login.html
+++ b/admin-login.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>SpotiDeals – Connexion Admin</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/style.css">
+  <style>
+    body {
+      font-family: sans-serif;
+      background-color: #f4f4f4;
+      color: #333;
+    }
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+    .header {
+      background: #333;
+      color: white;
+      padding: 1rem 0;
+    }
+    .header__inner {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .logo {
+      color: white;
+      text-decoration: none;
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
+    .nav a {
+      color: white;
+      text-decoration: none;
+      margin-left: 1rem;
+    }
+    .admin-panel {
+      max-width: 600px;
+      margin: 2rem auto;
+      padding: 2rem;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+      text-align: center;
+    }
+    .admin-panel input[type="password"], .admin-panel button {
+      padding: 10px;
+      margin-top: 10px;
+      border-radius: 4px;
+      border: 1px solid #ddd;
+    }
+    .admin-panel button {
+      background: #5cb85c;
+      color: white;
+      cursor: pointer;
+    }
+    .admin-panel button:hover {
+      background: #4cae4c;
+    }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div class="container header__inner">
+      <a href="index.html" class="logo">SpotiDeals</a>
+      <nav class="nav">
+        <a href="index.html">Accueil</a>
+        <a href="tracking.html">Suivi</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <div class="admin-panel">
+      <h1>Connexion Administrateur</h1>
+      <label for="adminPwd">Mot de passe :</label><br>
+      <input type="password" id="adminPwd" placeholder="Votre mot de passe"><br>
+      <button id="loginBtn">Accéder</button>
+    </div>
+  </main>
+  <script>
+    const ADMIN_PASSWORD = "1C1GCEA_enCA1146CA1146&oq=&gs_lcrp=EgZjaHJvbWUqEQgDEAAYAxhCGI8BGLQCGOoCMgkIABAjGCcY6gIyCQgBECMYJxjqAjIJCAIQIxgnGOoCMhEIAxAAGAMYQhiPARi0AhjqAjIRCAQQABgDGEIYjwEYtAIY6gIyEQg";
+    document.getElementById('loginBtn').addEventListener('click', () => {
+      const pwd = document.getElementById('adminPwd').value.trim();
+      if (pwd === ADMIN_PASSWORD) {
+        localStorage.setItem('adminPassword', pwd);
+        window.location.href = 'admin.html';
+      } else {
+        alert('Mot de passe incorrect.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/admin.html
+++ b/admin.html
@@ -197,11 +197,12 @@
     let allOrders = []; // Pour stocker toutes les commandes et filtrer localement
 
     function initAdminView() {
-    adminPassword = document.getElementById("adminPassword").value.trim();
-    if (adminPassword !== ADMIN_PASSWORD) {
-      alert("Mot de passe incorrect.");
-      return;
-    }
+      adminPassword = document.getElementById("adminPassword").value.trim();
+      if (adminPassword !== ADMIN_PASSWORD) {
+        alert("Mot de passe incorrect.");
+        return;
+      }
+      localStorage.setItem('adminPassword', adminPassword);
       document.querySelector('.password-section').style.display = 'none';
       document.getElementById('adminContent').style.display = 'block';
       loadOrders();
@@ -447,8 +448,13 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-      // Ne pas charger les commandes automatiquement, attendre la saisie du mot de passe
-      // loadOrders(); // Déplacé dans initAdminView
+      const stored = localStorage.getItem('adminPassword');
+      if (stored === ADMIN_PASSWORD) {
+        adminPassword = stored;
+        document.querySelector('.password-section').style.display = 'none';
+        document.getElementById('adminContent').style.display = 'block';
+        loadOrders();
+      }
       const searchInput = document.getElementById('searchBox');
       if (searchInput) {
           searchInput.addEventListener('input', filterOrders);


### PR DESCRIPTION
## Summary
- implement a separate `admin-login.html` page
- persist admin password in localStorage
- read saved password automatically on `admin.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e44a4ab8832eba9aa743b3fa0b43