### PR TITLE
Fix long lines and cleanup timeline dates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+admin-login.html

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/admin.html
+++ b/admin.html
@@ -1,195 +1,198 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>SpotiDeals – Administration</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="css/style.css">
-  <style>
-    body {
-      font-family: 'Roboto', sans-serif;
-      background-color: var(--bg);
-      color: var(--fg);
-    }
-    .container {
-      max-width: 900px; /* Augmenté pour plus d'espace */
-      margin: 0 auto;
-      padding: 1rem;
-    }
-    .header {
-      background: var(--card-bg);
-      color: var(--fg);
-      padding: 1rem 0;
-    }
-    .header__inner {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-    .logo {
-      color: var(--fg);
-      text-decoration: none;
-      font-size: 1.5rem;
-      font-weight: bold;
-    }
-    .nav a {
-      color: var(--fg);
-      text-decoration: none;
-      margin-left: 1rem;
-    }
-    .admin-panel {
-      max-width: 800px;
-      margin: 2rem auto;
-      padding: 2rem;
-      background: var(--card-bg);
-      border-radius: 8px;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.4);
-    }
-    .toolbar {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      margin-bottom: 1rem;
-      align-items: center;
-    }
-    .tool-btn {
-      padding: 8px 12px;
-      border-radius: 4px;
-      border: 1px solid var(--border-color);
-      background: var(--card-bg-alt);
-      cursor: pointer;
-      color: var(--fg);
-    }
-    .tool-btn:hover {
-      background: var(--hover-bg);
-    }
-    .tool-select {
-      padding: 8px 12px;
-      border-radius: 4px;
-      border: 1px solid var(--border-color);
-      background: var(--card-bg);
-      color: var(--fg);
-    }
-    .stats {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      margin-bottom: 1rem;
-    }
-    .stat-box {
-      flex: 1 1 120px;
-      background: var(--card-bg-alt);
-      border-radius: 4px;
-      padding: 10px;
-      text-align: center;
-      font-weight: bold;
-      color: var(--fg);
-    }
-    .password-section {
-      margin-bottom: 2rem;
-      padding: 1.5rem;
-      background-color: var(--card-bg-alt);
-      border-radius: 4px;
-      border: 1px solid var(--border-color);
-    }
-    .password-section input[type="password"], .password-section button {
-      padding: 10px;
-      margin-right: 10px;
-      border-radius: 4px;
-      border: 1px solid var(--border-color);
-      background: var(--card-bg);
-      color: var(--fg);
-    }
-    .password-section button {
-      background: #5cb85c;
-      color: white;
-      cursor: pointer;
-    }
-    .password-section button:hover {
-      background: #4cae4c;
-    }
-    .order-list {
-      margin-top: 2rem;
-    }
-    .order-item {
-      padding: 1.5rem; /* Augmenté */
-      border: 1px solid var(--border-color);
-      border-radius: 4px;
-      margin-bottom: 1.5rem; /* Augmenté */
-      background-color: var(--card-bg-alt);
-      color: var(--fg);
-    }
-    .order-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 1rem;
-      flex-wrap: wrap; /* Pour les petits écrans */
-    }
-    .order-details p {
-      margin: 0.5rem 0;
-      line-height: 1.6;
-    }
-    .order-actions label {
-      display: block;
-      margin-top: 0.5rem;
-      font-weight: bold;
-    }
-    .status-select, .notes-input {
-      width: calc(100% - 22px); /* Ajusté pour padding/border */
-      padding: 10px;
-      border-radius: 4px;
-      border: 1px solid var(--border-color);
-      margin-top: 0.25rem;
-      margin-bottom: 0.75rem;
-      background: var(--card-bg);
-      color: var(--fg);
-    }
-    .notes-input {
-      min-height: 60px; /* Hauteur pour les notes */
-      resize: vertical;
-    }
-    .save-btn {
-      background: #1DB954; /* Vert Spotify */
-      color: white;
-      border: none;
-      padding: 10px 20px;
-      border-radius: 20px; /* Plus arrondi */
-      cursor: pointer;
-      font-weight: bold;
-      transition: background-color 0.2s ease;
-      display: block; /* Pour centrer ou aligner facilement */
-      margin-top: 1rem;
-    }
-    .save-btn:hover {
-      background: #1ed760;
-    }
-    .search-box {
-      width: calc(100% - 24px); /* Ajusté */
-      padding: 12px;
-      margin-bottom: 1rem;
-      border: 1px solid var(--border-color);
-      border-radius: 4px;
-      font-size: 1rem;
-      background: var(--card-bg);
-      color: var(--fg);
-    }
-     #loadingIndicator, #errorMessage {
+  <head>
+    <meta charset="UTF-8" />
+    <title>SpotiDeals – Administration</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="css/style.css" />
+    <style>
+      body {
+        font-family: 'Roboto', sans-serif;
+        background-color: var(--bg);
+        color: var(--fg);
+      }
+      .container {
+        max-width: 900px; /* Augmenté pour plus d'espace */
+        margin: 0 auto;
+        padding: 1rem;
+      }
+      .header {
+        background: var(--card-bg);
+        color: var(--fg);
+        padding: 1rem 0;
+      }
+      .header__inner {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .logo {
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 1.5rem;
+        font-weight: bold;
+      }
+      .nav a {
+        color: var(--fg);
+        text-decoration: none;
+        margin-left: 1rem;
+      }
+      .admin-panel {
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 2rem;
+        background: var(--card-bg);
+        border-radius: 8px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+      }
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-bottom: 1rem;
+        align-items: center;
+      }
+      .tool-btn {
+        padding: 8px 12px;
+        border-radius: 4px;
+        border: 1px solid var(--border-color);
+        background: var(--card-bg-alt);
+        cursor: pointer;
+        color: var(--fg);
+      }
+      .tool-btn:hover {
+        background: var(--hover-bg);
+      }
+      .tool-select {
+        padding: 8px 12px;
+        border-radius: 4px;
+        border: 1px solid var(--border-color);
+        background: var(--card-bg);
+        color: var(--fg);
+      }
+      .stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-bottom: 1rem;
+      }
+      .stat-box {
+        flex: 1 1 120px;
+        background: var(--card-bg-alt);
+        border-radius: 4px;
+        padding: 10px;
+        text-align: center;
+        font-weight: bold;
+        color: var(--fg);
+      }
+      .password-section {
+        margin-bottom: 2rem;
+        padding: 1.5rem;
+        background-color: var(--card-bg-alt);
+        border-radius: 4px;
+        border: 1px solid var(--border-color);
+      }
+      .password-section input[type='password'],
+      .password-section button {
+        padding: 10px;
+        margin-right: 10px;
+        border-radius: 4px;
+        border: 1px solid var(--border-color);
+        background: var(--card-bg);
+        color: var(--fg);
+      }
+      .password-section button {
+        background: #5cb85c;
+        color: white;
+        cursor: pointer;
+      }
+      .password-section button:hover {
+        background: #4cae4c;
+      }
+      .order-list {
+        margin-top: 2rem;
+      }
+      .order-item {
+        padding: 1.5rem; /* Augmenté */
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        margin-bottom: 1.5rem; /* Augmenté */
+        background-color: var(--card-bg-alt);
+        color: var(--fg);
+      }
+      .order-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1rem;
+        flex-wrap: wrap; /* Pour les petits écrans */
+      }
+      .order-details p {
+        margin: 0.5rem 0;
+        line-height: 1.6;
+      }
+      .order-actions label {
+        display: block;
+        margin-top: 0.5rem;
+        font-weight: bold;
+      }
+      .status-select,
+      .notes-input {
+        width: calc(100% - 22px); /* Ajusté pour padding/border */
+        padding: 10px;
+        border-radius: 4px;
+        border: 1px solid var(--border-color);
+        margin-top: 0.25rem;
+        margin-bottom: 0.75rem;
+        background: var(--card-bg);
+        color: var(--fg);
+      }
+      .notes-input {
+        min-height: 60px; /* Hauteur pour les notes */
+        resize: vertical;
+      }
+      .save-btn {
+        background: #1db954; /* Vert Spotify */
+        color: white;
+        border: none;
+        padding: 10px 20px;
+        border-radius: 20px; /* Plus arrondi */
+        cursor: pointer;
+        font-weight: bold;
+        transition: background-color 0.2s ease;
+        display: block; /* Pour centrer ou aligner facilement */
+        margin-top: 1rem;
+      }
+      .save-btn:hover {
+        background: #1ed760;
+      }
+      .search-box {
+        width: calc(100% - 24px); /* Ajusté */
+        padding: 12px;
+        margin-bottom: 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        font-size: 1rem;
+        background: var(--card-bg);
+        color: var(--fg);
+      }
+      #loadingIndicator,
+      #errorMessage {
         text-align: center;
         padding: 1rem;
         margin-top: 1rem;
         border-radius: 4px;
-    }
-    #loadingIndicator {
+      }
+      #loadingIndicator {
         color: #007bff;
-    }
-    #errorMessage {
+      }
+      #errorMessage {
         color: #dc3545;
         background-color: #f8d7da;
         border: 1px solid #f5c6cb;
-    }
-    /* Styles pour le message de succès */
-    .success-message {
+      }
+      /* Styles pour le message de succès */
+      .success-message {
         padding: 10px;
         background-color: #d4edda; /* Vert clair */
         color: #155724; /* Texte vert foncé */
@@ -198,8 +201,8 @@
         margin-top: 10px;
         margin-bottom: 10px;
         text-align: center;
-    }
-    .logout-button {
+      }
+      .logout-button {
         background: #dc3545;
         color: white;
         border: none;
@@ -210,501 +213,523 @@
         transition: background-color 0.2s ease;
         margin-bottom: 1rem;
         float: right;
-    }
-    .logout-button:hover {
+      }
+      .logout-button:hover {
         background: #c82333;
-    }
-  </style>
-</head>
-<body>
-  <!-- HEADER -->
-  <header class="header">
-    <div class="container header__inner">
-      <a href="index.html" class="logo">SpotiDeals</a>
-      <nav class="nav">
-        <a href="index.html">Accueil</a>
-        <a href="tracking.html">Suivi</a>
-      </nav>
-    </div>
-  </header>
-
-  <!-- MAIN CONTENT -->
-  <main class="container">
-    <div class="admin-panel">
-      <h1>Administration des commandes</h1>
-
-      <div class="password-section">
-        <label for="adminPassword">Mot de passe Administrateur:</label>
-        <input type="password" id="adminPassword" placeholder="Votre mot de passe">
-        <button onclick="initAdminView()">Accéder</button>
+      }
+    </style>
+  </head>
+  <body>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="container header__inner">
+        <a href="index.html" class="logo">SpotiDeals</a>
+        <nav class="nav">
+          <a href="index.html">Accueil</a>
+          <a href="tracking.html">Suivi</a>
+        </nav>
       </div>
-      
-      <div id="adminContent" style="display: none;">
- qvc6qm-codex/créer-une-page-admin-complète
-        <div class="toolbar">
-          <input type="text" id="searchBox" class="search-box" placeholder="Rechercher par ID ou email">
-          <select id="statusFilter" class="tool-select">
-            <option value="all">Tous</option>
-            <option value="pending">En attente</option>
-            <option value="processing">En traitement</option>
-            <option value="completed">Complétées</option>
-          </select>
-          <select id="sortSelect" class="tool-select">
-            <option value="date-desc">Date ▼</option>
-            <option value="date-asc">Date ▲</option>
-          </select>
-          <button class="tool-btn" onclick="exportCSV()">Exporter CSV</button>
-          <button class="tool-btn" onclick="printList()">Imprimer</button>
-          <button class="tool-btn" id="logoutBtn">Déconnexion</button>
+    </header>
+
+    <!-- MAIN CONTENT -->
+    <main class="container">
+      <div class="admin-panel">
+        <h1>Administration des commandes</h1>
+
+        <div class="password-section">
+          <label for="adminPassword">Mot de passe Administrateur:</label>
+          <input type="password" id="adminPassword" placeholder="Votre mot de passe" />
+          <button onclick="initAdminView()">Accéder</button>
         </div>
-        <div class="stats">
-          <div id="stat-total" class="stat-box">Total: 0</div>
-          <div id="stat-pending" class="stat-box">En attente: 0</div>
-          <div id="stat-today" class="stat-box">Aujourd'hui: 0</div>
-          <div id="stat-week" class="stat-box">Complété cette semaine: 0%</div>
-        </div>
-=======
-        <input type="text" id="searchBox" class="search-box" placeholder="Rechercher une commande par ID, email...">
-        <button id="logoutBtn" class="logout-button">Déconnexion</button>
- main
-        <div id="loadingIndicator" style="display: none;">Chargement des commandes...</div>
-        <div id="errorMessage" style="display: none;"></div>
-        <div id="orderList" class="order-list">
-          <!-- Les commandes seront ajoutées ici -->
+
+        <div id="adminContent" style="display: none">
+          qvc6qm-codex/créer-une-page-admin-complète
+          <div class="toolbar">
+            <input type="text" id="searchBox" class="search-box" placeholder="Rechercher par ID ou email" />
+            <select id="statusFilter" class="tool-select">
+              <option value="all">Tous</option>
+              <option value="pending">En attente</option>
+              <option value="processing">En traitement</option>
+              <option value="completed">Complétées</option>
+            </select>
+            <select id="sortSelect" class="tool-select">
+              <option value="date-desc">Date ▼</option>
+              <option value="date-asc">Date ▲</option>
+            </select>
+            <button class="tool-btn" onclick="exportCSV()">Exporter CSV</button>
+            <button class="tool-btn" onclick="printList()">Imprimer</button>
+            <button class="tool-btn" id="logoutBtn">Déconnexion</button>
+          </div>
+          <div class="stats">
+            <div id="stat-total" class="stat-box">Total: 0</div>
+            <div id="stat-pending" class="stat-box">En attente: 0</div>
+            <div id="stat-today" class="stat-box">Aujourd'hui: 0</div>
+            <div id="stat-week" class="stat-box">Complété cette semaine: 0%</div>
+          </div>
+          =======
+          <input type="text" id="searchBox" class="search-box" placeholder="Rechercher une commande par ID, email..." />
+          <button id="logoutBtn" class="logout-button">Déconnexion</button>
+          main
+          <div id="loadingIndicator" style="display: none">Chargement des commandes...</div>
+          <div id="errorMessage" style="display: none"></div>
+          <div id="orderList" class="order-list">
+            <!-- Les commandes seront ajoutées ici -->
+          </div>
         </div>
       </div>
-    </div>
-  </main>
+    </main>
 
-  <script>
-    // --- IMPORTANT: METTEZ À JOUR AVEC VOTRE NOUVELLE URL DE SCRIPT ---
-    const API_URL = 'https://script.google.com/macros/s/AKfycbxEmJdgcerK1ENvsy8IvSnAZDJ6p4fr9hfO87haKbKrVXZaRf2Z3wnRzyQSDl527VtW/exec';
- qvc6qm-codex/créer-une-page-admin-complète
-    const ADMIN_PASSWORD_HASH = '713bfda78870bf9d1b261f565286f85e97ee614efe5f0faf7c34e7ca4f65baca';
-=======
-    const ADMIN_PASSWORD_HASH = "db4820111574318070358f047cc49d2aa7bc6e6e614af9ea8083c2c3f95b2569";
- main
-    // --- IMPORTANT: METTEZ À JOUR AVEC VOTRE NOUVELLE URL DE SCRIPT ---
-    let adminPasswordHash = "";
-    let allOrders = []; // Pour stocker toutes les commandes et filtrer localement
+    <script>
+          // --- IMPORTANT: METTEZ À JOUR AVEC VOTRE NOUVELLE URL DE SCRIPT ---
+          const API_URL =
+            'https://script.google.com/macros/s/' +
+            'AKfycbxEmJdgcerK1ENvsy8IvSnAZDJ6p4fr9hfO87haKbKrVXZaRf2Z3wnRzyQSDl527VtW/exec';
+          const ADMIN_PASSWORD_HASH =
+            'db4820111574318070358f047cc49d2aa7bc6e6e614af9ea8083c2c3f95b2569';
+       main
+          // --- IMPORTANT: METTEZ À JOUR AVEC VOTRE NOUVELLE URL DE SCRIPT ---
+          let adminPasswordHash = "";
+          let allOrders = []; // Pour stocker toutes les commandes et filtrer localement
 
- qvc6qm-codex/créer-une-page-admin-complète
-    async function hashPassword(str) {
-      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
-      return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
-    }
-
-    async function initAdminView() {
-      const input = document.getElementById("adminPassword").value.trim();
-      const hashed = await hashPassword(input);
-      if (hashed !== ADMIN_PASSWORD_HASH) {
-        alert("Mot de passe incorrect.");
-        return;
-      }
-      adminPasswordHash = hashed;
-      localStorage.setItem('adminHash', hashed);
-      document.querySelector('.password-section').style.display = 'none';
-      document.getElementById('adminContent').style.display = 'block';
-      loadOrders();
-=======
-    async function hashPassword(pwd) {
-      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(pwd));
-      return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
-    }
-
-    function initAdminView() {
-      const pwd = document.getElementById("adminPassword").value.trim();
-      hashPassword(pwd).then(hash => {
-        adminPasswordHash = hash;
-        if (adminPasswordHash !== ADMIN_PASSWORD_HASH) {
-          alert("Mot de passe incorrect.");
-          return;
-        }
-        localStorage.setItem('adminPasswordHash', adminPasswordHash);
-        document.querySelector('.password-section').style.display = 'none';
-        document.getElementById('adminContent').style.display = 'block';
-        loadOrders();
-      });
- main
-    }
-
-    async function loadOrders() {
-      const loadingIndicator = document.getElementById('loadingIndicator');
-      const errorMessage = document.getElementById('errorMessage');
-      const orderList = document.getElementById('orderList');
-      
-      loadingIndicator.style.display = 'block';
-      errorMessage.style.display = 'none';
-      orderList.textContent = '';
-
-
-      try {
-        // Pour charger les commandes, nous utilisons doGet, pas besoin de mot de passe ici
-        // car le script Google ne le demande pas pour doGet (lecture de toutes les commandes).
-        // Le mot de passe sera utilisé pour les actions POST (mise à jour).
-        const res = await fetch(API_URL);
-        if (!res.ok) {
-            const errorData = await res.json().catch(() => ({ error: `Erreur HTTP: ${res.status}` }));
-            throw new Error(errorData.error || `Erreur HTTP: ${res.status}`);
-        }
-        allOrders = await res.json();
-        if (allOrders.error) {
-            throw new Error(allOrders.error);
-        }
-        updateStats(allOrders);
-        displayOrders(sortOrders(allOrders));
-      } catch (error) {
-        console.error("Erreur lors du chargement des commandes:", error);
-        errorMessage.textContent = "Erreur lors du chargement des commandes: " + error.message;
-        errorMessage.style.display = 'block';
-      } finally {
-        loadingIndicator.style.display = 'none';
-      }
-    }
-
-    function displayOrders(orders) {
-      const container = document.getElementById('orderList');
-      container.textContent = '';
-      if (orders.length === 0) {
-        const p = document.createElement('p');
-        p.textContent = 'Aucune commande à afficher.';
-        container.appendChild(p);
-        return;
-      }
-
-      orders.forEach(order => {
-        const div = document.createElement('div');
-        div.className = 'order-item';
-        div.dataset.orderId = order.orderID; // Stocker l'ID pour référence
-
-        // Convertir la date si elle est valide
-        let formattedDate = 'Date inconnue';
-        if (order.date) {
-            const dateObj = new Date(order.date);
-            if (!isNaN(dateObj)) {
-                formattedDate = dateObj.toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
-            } else {
-                // Essayer de parser si c'est une chaîne de type "YYYY-MM-DD" ou similaire
-                const parts = String(order.date).split(/[-/]/);
-                if (parts.length === 3) {
-                    // Attention: new Date(year, monthIndex, day)
-                    const potentialDate = new Date(parts[0], parts[1] - 1, parts[2]);
-                    if(!isNaN(potentialDate)){
-                        formattedDate = potentialDate.toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
-                    } else if (String(order.date).includes("T")) { // Si c'est un format ISO avec T
-                         const isoDate = new Date(String(order.date));
-                         if(!isNaN(isoDate)) {
-                            formattedDate = isoDate.toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
-                         } else {
-                            formattedDate = String(order.date); // Afficher tel quel si parsing échoue
-                         }
-                    } else {
-                       formattedDate = String(order.date); // Afficher tel quel
-                    }
-                } else {
-                    formattedDate = String(order.date); // Afficher tel quel
-                }
-            }
-        }
-
-
-        const header = document.createElement('div');
-        header.className = 'order-header';
-        const h3 = document.createElement('h3');
-        h3.textContent = `Commande: ${order.orderID}`;
-        header.appendChild(h3);
-
-        const details = document.createElement('div');
-        details.className = 'order-details';
-
-        const emailP = document.createElement('p');
-        const emailStrong = document.createElement('strong');
-        emailStrong.textContent = 'Email:';
-        emailP.appendChild(emailStrong);
-        emailP.appendChild(document.createTextNode(' ' + (order.email || 'Non fourni')));
-        details.appendChild(emailP);
-
-        const dateP = document.createElement('p');
-        const dateStrong = document.createElement('strong');
-        dateStrong.textContent = 'Date:';
-        dateP.appendChild(dateStrong);
-        dateP.appendChild(document.createTextNode(' ' + formattedDate));
-        details.appendChild(dateP);
-
-        const actions = document.createElement('div');
-        actions.className = 'order-actions';
-
-        const labelStatus = document.createElement('label');
-        labelStatus.setAttribute('for', `status-${order.orderID}`);
-        labelStatus.textContent = 'Statut:';
-        actions.appendChild(labelStatus);
-
-        const select = document.createElement('select');
-        select.id = `status-${order.orderID}`;
-        select.className = 'status-select';
-        const options = [
-          ['pending', 'En attente'],
-          ['processing', 'En traitement'],
-          ['completed', 'Complétée'],
-          ['cancelled', 'Annulée'],
-          ['refunded', 'Remboursée']
-        ];
-        options.forEach(([value, label]) => {
-          const opt = document.createElement('option');
-          opt.value = value;
-          opt.textContent = label;
-          if (order.status === value) opt.selected = true;
-          select.appendChild(opt);
-        });
-        actions.appendChild(select);
-
-        const labelNotes = document.createElement('label');
-        labelNotes.setAttribute('for', `notes-${order.orderID}`);
-        labelNotes.textContent = 'Notes (visibles par le client si la page suivi les affiche):';
-        actions.appendChild(labelNotes);
-
-        const textarea = document.createElement('textarea');
-        textarea.id = `notes-${order.orderID}`;
-        textarea.className = 'notes-input';
-        textarea.rows = 3;
-        textarea.textContent = order.notes || '';
-        actions.appendChild(textarea);
-
-        const saveBtn = document.createElement('button');
-        saveBtn.className = 'save-btn';
-        saveBtn.textContent = '✏️ Sauvegarder';
-        saveBtn.addEventListener('click', () => updateOrder(order.orderID));
-        actions.appendChild(saveBtn);
-
-        const emailBtn = document.createElement('button');
-        emailBtn.className = 'save-btn';
-        emailBtn.textContent = '📧';
-        emailBtn.title = 'Renvoyer l\'email';
-        emailBtn.addEventListener('click', () => resendEmail(order.orderID));
-        actions.appendChild(emailBtn);
-
-        const delBtn = document.createElement('button');
-        delBtn.className = 'save-btn';
-        delBtn.textContent = '🗑️';
-        delBtn.title = 'Supprimer';
-        delBtn.addEventListener('click', () => deleteOrder(order.orderID));
-        actions.appendChild(delBtn);
-
-        const msgDiv = document.createElement('div');
-        msgDiv.id = `message-${order.orderID}`;
-        msgDiv.style.marginTop = '10px';
-        actions.appendChild(msgDiv);
-
-        details.appendChild(actions);
-
-        div.appendChild(header);
-        div.appendChild(details);
-
-        container.appendChild(div);
-      });
-    }
-
-    async function updateOrder(orderID) {
-      const status = document.getElementById(`status-${orderID}`).value;
-      const notes = document.getElementById(`notes-${orderID}`).value;
-      const messageDiv = document.getElementById(`message-${orderID}`);
-      messageDiv.textContent = ''; // Clear previous messages
-      messageDiv.className = ''; // Clear previous styling
-
-      if (!adminPasswordHash) {
-        alert("Le mot de passe administrateur est requis pour cette action. Veuillez le saisir en haut de la page.");
-        // Remettre le focus sur le champ de mot de passe ou afficher la section
-        document.querySelector('.password-section').style.display = 'block';
-        document.getElementById('adminPassword').focus();
-        return;
-      }
-      
-      const loadingIndicator = document.getElementById('loadingIndicator');
-      loadingIndicator.style.display = 'block';
-
-
-      try {
-        const res = await fetch(API_URL, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json', // Important pour que Apps Script parse e.postData.contents
-          },
-          body: JSON.stringify({
-            password: adminPasswordHash,
-            action: 'updateOrder',
-            orderID: orderID,
-            status: status,
-            notes: notes
-          })
-        });
-
-        const result = await res.json();
-        loadingIndicator.style.display = 'none';
-
-        if (result.success) {
-          messageDiv.textContent = result.message || "Commande mise à jour avec succès!";
-          messageDiv.className = 'success-message'; // Appliquer le style de succès
-          // Optionnel: Mettre à jour l'objet `allOrders` localement pour refléter le changement immédiatement
-          const orderIndex = allOrders.findIndex(o => o.orderID === orderID);
-          if (orderIndex > -1) {
-            allOrders[orderIndex].status = status;
-            allOrders[orderIndex].notes = notes;
+       qvc6qm-codex/créer-une-page-admin-complète
+          async function hashPassword(str) {
+            const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+            return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
           }
-          updateStats(allOrders);
-        } else {
-          messageDiv.textContent = "Erreur: " + (result.error || "Impossible de mettre à jour la commande.");
-          messageDiv.className = 'error-message'; // Appliquer un style d'erreur (à définir dans CSS)
-        }
-      } catch (error) {
-        loadingIndicator.style.display = 'none';
-        messageDiv.textContent = "Erreur de communication: " + error.message;
-        messageDiv.className = 'error-message';
-        console.error("Erreur lors de la mise à jour:", error);
-      }
 
-      // Cacher le message après quelques secondes
-      setTimeout(() => {
-        messageDiv.textContent = '';
-        messageDiv.className = '';
-      }, 5000);
-    }
+          async function initAdminView() {
+            const input = document.getElementById("adminPassword").value.trim();
+            const hashed = await hashPassword(input);
+            if (hashed !== ADMIN_PASSWORD_HASH) {
+              alert("Mot de passe incorrect.");
+              return;
+            }
+            adminPasswordHash = hashed;
+            localStorage.setItem('adminHash', hashed);
+            document.querySelector('.password-section').style.display = 'none';
+            document.getElementById('adminContent').style.display = 'block';
+            loadOrders();
+      =======
+          async function hashPassword(pwd) {
+            const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(pwd));
+            return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+          }
 
-    async function resendEmail(orderID) {
-      if (!adminPasswordHash) return alert('Mot de passe requis');
-      const res = await fetch(API_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ password: adminPasswordHash, action: 'resendEmail', orderID })
-      });
-      const data = await res.json().catch(() => ({}));
-      alert(data.message || 'Email renvoyé');
-    }
+          function initAdminView() {
+            const pwd = document.getElementById("adminPassword").value.trim();
+            hashPassword(pwd).then(hash => {
+              adminPasswordHash = hash;
+              if (adminPasswordHash !== ADMIN_PASSWORD_HASH) {
+                alert("Mot de passe incorrect.");
+                return;
+              }
+              localStorage.setItem('adminPasswordHash', adminPasswordHash);
+              document.querySelector('.password-section').style.display = 'none';
+              document.getElementById('adminContent').style.display = 'block';
+              loadOrders();
+            });
+       main
+          }
 
-    async function deleteOrder(orderID) {
-      if (!adminPasswordHash) return alert('Mot de passe requis');
-      if (!confirm('Supprimer cette commande ?')) return;
-      const res = await fetch(API_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ password: adminPasswordHash, action: 'deleteOrder', orderID })
-      });
-      const data = await res.json().catch(() => ({}));
-      if (data.success) {
-        allOrders = allOrders.filter(o => o.orderID !== orderID);
-        filterOrders();
-        updateStats(allOrders);
-      } else {
-        alert(data.error || 'Erreur lors de la suppression');
-      }
-    }
+          async function loadOrders() {
+            const loadingIndicator = document.getElementById('loadingIndicator');
+            const errorMessage = document.getElementById('errorMessage');
+            const orderList = document.getElementById('orderList');
 
-    function exportCSV() {
-      if (!allOrders.length) return;
-      const headers = ['orderID','email','date','status','notes'];
-      const rows = allOrders.map(o => headers.map(h => (o[h] || '').toString().replace(/"/g,'""')));
-      const csv = [headers.join(','), ...rows.map(r => '"' + r.join('","') + '"')].join('\n');
-      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'orders.csv';
-      a.click();
-      URL.revokeObjectURL(url);
-    }
+            loadingIndicator.style.display = 'block';
+            errorMessage.style.display = 'none';
+            orderList.textContent = '';
 
-    function printList() {
-      window.print();
-    }
 
-    function logout() {
-      localStorage.removeItem('adminHash');
-      window.location.href = 'admin-login.html';
-    }
+            try {
+              // Pour charger les commandes, nous utilisons doGet, pas besoin de mot de passe ici
+              // car le script Google ne le demande pas pour doGet (lecture de toutes les commandes).
+              // Le mot de passe sera utilisé pour les actions POST (mise à jour).
+              const res = await fetch(API_URL);
+              if (!res.ok) {
+                  const errorData = await res.json().catch(() => ({ error: `Erreur HTTP: ${res.status}` }));
+                  throw new Error(errorData.error || `Erreur HTTP: ${res.status}`);
+              }
+              allOrders = await res.json();
+              if (allOrders.error) {
+                  throw new Error(allOrders.error);
+              }
+              updateStats(allOrders);
+              displayOrders(sortOrders(allOrders));
+            } catch (error) {
+              console.error("Erreur lors du chargement des commandes:", error);
+              errorMessage.textContent = "Erreur lors du chargement des commandes: " + error.message;
+              errorMessage.style.display = 'block';
+            } finally {
+              loadingIndicator.style.display = 'none';
+            }
+          }
 
-    function updateStats(data) {
-      const total = data.length;
-      const pending = data.filter(o => o.status === 'pending').length;
-      const today = data.filter(o => {
-        const d = new Date(o.date);
-        const n = new Date();
-        return d.getFullYear() === n.getFullYear() && d.getMonth() === n.getMonth() && d.getDate() === n.getDate();
-      }).length;
-      const now = new Date();
-      const weekStart = new Date(now);
-      weekStart.setDate(now.getDate() - ((now.getDay() + 6) % 7));
-      const completedWeek = data.filter(o => o.status === 'completed' && new Date(o.date) >= weekStart).length;
-      const weekTotal = data.filter(o => new Date(o.date) >= weekStart).length;
-      const percent = weekTotal ? Math.round((completedWeek / weekTotal) * 100) : 0;
-      document.getElementById('stat-total').textContent = `Total: ${total}`;
-      document.getElementById('stat-pending').textContent = `En attente: ${pending}`;
-      document.getElementById('stat-today').textContent = `Aujourd'hui: ${today}`;
-      document.getElementById('stat-week').textContent = `Complété cette semaine: ${percent}%`;
-    }
+          function displayOrders(orders) {
+            const container = document.getElementById('orderList');
+            container.textContent = '';
+            if (orders.length === 0) {
+              const p = document.createElement('p');
+              p.textContent = 'Aucune commande à afficher.';
+              container.appendChild(p);
+              return;
+            }
 
-    function sortOrders(list) {
-      const sort = document.getElementById('sortSelect').value;
-      return list.slice().sort((a,b) => {
-        const da = new Date(a.date); const db = new Date(b.date);
-        if (sort === 'date-asc') return da - db;
-        return db - da;
-      });
-    }
+            orders.forEach(order => {
+              const div = document.createElement('div');
+              div.className = 'order-item';
+              div.dataset.orderId = order.orderID; // Stocker l'ID pour référence
 
-    function filterOrders() {
-        const search = document.getElementById('searchBox').value.toLowerCase();
-        const statusFilter = document.getElementById('statusFilter').value;
-        if (!allOrders || allOrders.length === 0) return;
+              // Convertir la date si elle est valide
+              let formattedDate = 'Date inconnue';
+              if (order.date) {
+                  const dateObj = new Date(order.date);
+                  if (!isNaN(dateObj)) {
+                      formattedDate = dateObj.toLocaleDateString('fr-FR', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
+                      });
+                  } else {
+                      // Essayer de parser si c'est une chaîne de type "YYYY-MM-DD" ou similaire
+                      const parts = String(order.date).split(/[-/]/);
+                      if (parts.length === 3) {
+                          // Attention: new Date(year, monthIndex, day)
+                          const potentialDate = new Date(parts[0], parts[1] - 1, parts[2]);
+                          if(!isNaN(potentialDate)){
+                              formattedDate = potentialDate.toLocaleDateString('fr-FR', {
+                                year: 'numeric',
+                                month: 'long',
+                                day: 'numeric'
+                              });
+                          } else if (String(order.date).includes("T")) { // Si c'est un format ISO avec T
+                               const isoDate = new Date(String(order.date));
+                               if(!isNaN(isoDate)) {
+                                  formattedDate = isoDate.toLocaleDateString('fr-FR', {
+                                    year: 'numeric',
+                                    month: 'long',
+                                    day: 'numeric'
+                                  });
+                               } else {
+                                  formattedDate = String(order.date); // Afficher tel quel si parsing échoue
+                               }
+                          } else {
+                             formattedDate = String(order.date); // Afficher tel quel
+                          }
+                      } else {
+                          formattedDate = String(order.date); // Afficher tel quel
+                      }
+                  }
+              }
 
-        let filtered = allOrders.filter(order => {
-          const orderID = order.orderID ? String(order.orderID).toLowerCase() : '';
-          const email = order.email ? String(order.email).toLowerCase() : '';
-          const status = order.status ? String(order.status).toLowerCase() : '';
-          const notes = order.notes ? String(order.notes).toLowerCase() : '';
-          const searchMatch = orderID.includes(search) || email.includes(search) || status.includes(search) || notes.includes(search);
-          const statusMatch = statusFilter === 'all' || status === statusFilter;
-          return searchMatch && statusMatch;
-        });
-        filtered = sortOrders(filtered);
-        displayOrders(filtered);
-        updateStats(filtered);
-    }
 
-    function logout() {
-      localStorage.removeItem('adminPassword');
-      window.location.href = 'admin-login.html';
-    }
+              const header = document.createElement('div');
+              header.className = 'order-header';
+              const h3 = document.createElement('h3');
+              h3.textContent = `Commande: ${order.orderID}`;
+              header.appendChild(h3);
 
-    document.addEventListener('DOMContentLoaded', () => {
- qvc6qm-codex/créer-une-page-admin-complète
-      const stored = localStorage.getItem('adminHash');
-=======
-      const stored = localStorage.getItem('adminPasswordHash');
- main
-      if (stored === ADMIN_PASSWORD_HASH) {
-        adminPasswordHash = stored;
-        document.querySelector('.password-section').style.display = 'none';
-        document.getElementById('adminContent').style.display = 'block';
-        loadOrders();
-      }
-      const searchInput = document.getElementById('searchBox');
-      if (searchInput) {
-          searchInput.addEventListener('input', filterOrders);
-      }
- qvc6qm-codex/créer-une-page-admin-complète
-      const statusSelect = document.getElementById('statusFilter');
-      if (statusSelect) statusSelect.addEventListener('change', filterOrders);
-      const sortSelect = document.getElementById('sortSelect');
-      if (sortSelect) sortSelect.addEventListener('change', filterOrders);
-      const logoutBtn = document.getElementById('logoutBtn');
-      if (logoutBtn) logoutBtn.addEventListener('click', logout);
-=======
-      const logoutBtn = document.getElementById('logoutBtn');
-      if (logoutBtn) {
-          logoutBtn.addEventListener('click', logout);
-      }
- main
-    });
-  </script>
-  <script src="js/main.js"></script>
-</body>
+              const details = document.createElement('div');
+              details.className = 'order-details';
+
+              const emailP = document.createElement('p');
+              const emailStrong = document.createElement('strong');
+              emailStrong.textContent = 'Email:';
+              emailP.appendChild(emailStrong);
+              emailP.appendChild(document.createTextNode(' ' + (order.email || 'Non fourni')));
+              details.appendChild(emailP);
+
+              const dateP = document.createElement('p');
+              const dateStrong = document.createElement('strong');
+              dateStrong.textContent = 'Date:';
+              dateP.appendChild(dateStrong);
+              dateP.appendChild(document.createTextNode(' ' + formattedDate));
+              details.appendChild(dateP);
+
+              const actions = document.createElement('div');
+              actions.className = 'order-actions';
+
+              const labelStatus = document.createElement('label');
+              labelStatus.setAttribute('for', `status-${order.orderID}`);
+              labelStatus.textContent = 'Statut:';
+              actions.appendChild(labelStatus);
+
+              const select = document.createElement('select');
+              select.id = `status-${order.orderID}`;
+              select.className = 'status-select';
+              const options = [
+                ['pending', 'En attente'],
+                ['processing', 'En traitement'],
+                ['completed', 'Complétée'],
+                ['cancelled', 'Annulée'],
+                ['refunded', 'Remboursée']
+              ];
+              options.forEach(([value, label]) => {
+                const opt = document.createElement('option');
+                opt.value = value;
+                opt.textContent = label;
+                if (order.status === value) opt.selected = true;
+                select.appendChild(opt);
+              });
+              actions.appendChild(select);
+
+              const labelNotes = document.createElement('label');
+              labelNotes.setAttribute('for', `notes-${order.orderID}`);
+              labelNotes.textContent = 'Notes (visibles par le client si la page suivi les affiche):';
+              actions.appendChild(labelNotes);
+
+              const textarea = document.createElement('textarea');
+              textarea.id = `notes-${order.orderID}`;
+              textarea.className = 'notes-input';
+              textarea.rows = 3;
+              textarea.textContent = order.notes || '';
+              actions.appendChild(textarea);
+
+              const saveBtn = document.createElement('button');
+              saveBtn.className = 'save-btn';
+              saveBtn.textContent = '✏️ Sauvegarder';
+              saveBtn.addEventListener('click', () => updateOrder(order.orderID));
+              actions.appendChild(saveBtn);
+
+              const emailBtn = document.createElement('button');
+              emailBtn.className = 'save-btn';
+              emailBtn.textContent = '📧';
+              emailBtn.title = 'Renvoyer l\'email';
+              emailBtn.addEventListener('click', () => resendEmail(order.orderID));
+              actions.appendChild(emailBtn);
+
+              const delBtn = document.createElement('button');
+              delBtn.className = 'save-btn';
+              delBtn.textContent = '🗑️';
+              delBtn.title = 'Supprimer';
+              delBtn.addEventListener('click', () => deleteOrder(order.orderID));
+              actions.appendChild(delBtn);
+
+              const msgDiv = document.createElement('div');
+              msgDiv.id = `message-${order.orderID}`;
+              msgDiv.style.marginTop = '10px';
+              actions.appendChild(msgDiv);
+
+              details.appendChild(actions);
+
+              div.appendChild(header);
+              div.appendChild(details);
+
+              container.appendChild(div);
+            });
+          }
+
+          async function updateOrder(orderID) {
+            const status = document.getElementById(`status-${orderID}`).value;
+            const notes = document.getElementById(`notes-${orderID}`).value;
+            const messageDiv = document.getElementById(`message-${orderID}`);
+            messageDiv.textContent = ''; // Clear previous messages
+            messageDiv.className = ''; // Clear previous styling
+
+            if (!adminPasswordHash) {
+              alert(
+                "Le mot de passe administrateur est requis pour cette action. Veuillez le saisir en haut de la page."
+              );
+              // Remettre le focus sur le champ de mot de passe ou afficher la section
+              document.querySelector('.password-section').style.display = 'block';
+              document.getElementById('adminPassword').focus();
+              return;
+            }
+
+            const loadingIndicator = document.getElementById('loadingIndicator');
+            loadingIndicator.style.display = 'block';
+
+
+            try {
+              const res = await fetch(API_URL, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json', // Important pour que Apps Script parse e.postData.contents
+                },
+                body: JSON.stringify({
+                  password: adminPasswordHash,
+                  action: 'updateOrder',
+                  orderID: orderID,
+                  status: status,
+                  notes: notes
+                })
+              });
+
+              const result = await res.json();
+              loadingIndicator.style.display = 'none';
+
+              if (result.success) {
+                messageDiv.textContent = result.message || "Commande mise à jour avec succès!";
+                messageDiv.className = 'success-message'; // Appliquer le style de succès
+                // Optionnel: Mettre à jour l'objet `allOrders` localement pour refléter le changement immédiatement
+                const orderIndex = allOrders.findIndex(o => o.orderID === orderID);
+                if (orderIndex > -1) {
+                  allOrders[orderIndex].status = status;
+                  allOrders[orderIndex].notes = notes;
+                }
+                updateStats(allOrders);
+              } else {
+                messageDiv.textContent = "Erreur: " + (result.error || "Impossible de mettre à jour la commande.");
+                messageDiv.className = 'error-message'; // Appliquer un style d'erreur (à définir dans CSS)
+              }
+            } catch (error) {
+              loadingIndicator.style.display = 'none';
+              messageDiv.textContent = "Erreur de communication: " + error.message;
+              messageDiv.className = 'error-message';
+              console.error("Erreur lors de la mise à jour:", error);
+            }
+
+            // Cacher le message après quelques secondes
+            setTimeout(() => {
+              messageDiv.textContent = '';
+              messageDiv.className = '';
+            }, 5000);
+          }
+
+          async function resendEmail(orderID) {
+            if (!adminPasswordHash) return alert('Mot de passe requis');
+            const res = await fetch(API_URL, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ password: adminPasswordHash, action: 'resendEmail', orderID })
+            });
+            const data = await res.json().catch(() => ({}));
+            alert(data.message || 'Email renvoyé');
+          }
+
+          async function deleteOrder(orderID) {
+            if (!adminPasswordHash) return alert('Mot de passe requis');
+            if (!confirm('Supprimer cette commande ?')) return;
+            const res = await fetch(API_URL, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ password: adminPasswordHash, action: 'deleteOrder', orderID })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (data.success) {
+              allOrders = allOrders.filter(o => o.orderID !== orderID);
+              filterOrders();
+              updateStats(allOrders);
+            } else {
+              alert(data.error || 'Erreur lors de la suppression');
+            }
+          }
+
+          function exportCSV() {
+            if (!allOrders.length) return;
+            const headers = ['orderID','email','date','status','notes'];
+            const rows = allOrders.map(o => headers.map(h => (o[h] || '').toString().replace(/"/g,'""')));
+            const csv = [headers.join(','), ...rows.map(r => '"' + r.join('","') + '"')].join('\n');
+            const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'orders.csv';
+            a.click();
+            URL.revokeObjectURL(url);
+          }
+
+          function printList() {
+            window.print();
+          }
+
+          function logout() {
+            localStorage.removeItem('adminHash');
+            window.location.href = 'admin-login.html';
+          }
+
+          function updateStats(data) {
+            const total = data.length;
+            const pending = data.filter(o => o.status === 'pending').length;
+            const today = data.filter(o => {
+              const d = new Date(o.date);
+              const n = new Date();
+              return (
+                d.getFullYear() === n.getFullYear() &&
+                d.getMonth() === n.getMonth() &&
+                d.getDate() === n.getDate()
+              );
+            }).length;
+            const now = new Date();
+            const weekStart = new Date(now);
+            weekStart.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+            const completedWeek = data.filter(o => o.status === 'completed' && new Date(o.date) >= weekStart).length;
+            const weekTotal = data.filter(o => new Date(o.date) >= weekStart).length;
+            const percent = weekTotal ? Math.round((completedWeek / weekTotal) * 100) : 0;
+            document.getElementById('stat-total').textContent = `Total: ${total}`;
+            document.getElementById('stat-pending').textContent = `En attente: ${pending}`;
+            document.getElementById('stat-today').textContent = `Aujourd'hui: ${today}`;
+            document.getElementById('stat-week').textContent = `Complété cette semaine: ${percent}%`;
+          }
+
+          function sortOrders(list) {
+            const sort = document.getElementById('sortSelect').value;
+            return list.slice().sort((a,b) => {
+              const da = new Date(a.date); const db = new Date(b.date);
+              if (sort === 'date-asc') return da - db;
+              return db - da;
+            });
+          }
+
+          function filterOrders() {
+              const search = document.getElementById('searchBox').value.toLowerCase();
+              const statusFilter = document.getElementById('statusFilter').value;
+              if (!allOrders || allOrders.length === 0) return;
+
+              let filtered = allOrders.filter(order => {
+                const orderID = order.orderID ? String(order.orderID).toLowerCase() : '';
+                const email = order.email ? String(order.email).toLowerCase() : '';
+                const status = order.status ? String(order.status).toLowerCase() : '';
+                const notes = order.notes ? String(order.notes).toLowerCase() : '';
+                const searchMatch =
+                  orderID.includes(search) ||
+                  email.includes(search) ||
+                  status.includes(search) ||
+                  notes.includes(search);
+                const statusMatch = statusFilter === 'all' || status === statusFilter;
+                return searchMatch && statusMatch;
+              });
+              filtered = sortOrders(filtered);
+              displayOrders(filtered);
+              updateStats(filtered);
+          }
+
+          function logout() {
+            localStorage.removeItem('adminPassword');
+            window.location.href = 'admin-login.html';
+          }
+
+          document.addEventListener('DOMContentLoaded', () => {
+       qvc6qm-codex/créer-une-page-admin-complète
+            const stored = localStorage.getItem('adminHash');
+      =======
+            const stored = localStorage.getItem('adminPasswordHash');
+       main
+            if (stored === ADMIN_PASSWORD_HASH) {
+              adminPasswordHash = stored;
+              document.querySelector('.password-section').style.display = 'none';
+              document.getElementById('adminContent').style.display = 'block';
+              loadOrders();
+            }
+            const searchInput = document.getElementById('searchBox');
+            if (searchInput) {
+                searchInput.addEventListener('input', filterOrders);
+            }
+       qvc6qm-codex/créer-une-page-admin-complète
+            const statusSelect = document.getElementById('statusFilter');
+            if (statusSelect) statusSelect.addEventListener('change', filterOrders);
+            const sortSelect = document.getElementById('sortSelect');
+            if (sortSelect) sortSelect.addEventListener('change', filterOrders);
+            const logoutBtn = document.getElementById('logoutBtn');
+            if (logoutBtn) logoutBtn.addEventListener('click', logout);
+      =======
+            const logoutBtn = document.getElementById('logoutBtn');
+            if (logoutBtn) {
+                logoutBtn.addEventListener('click', logout);
+            }
+       main
+          });
+    </script>
+    <script src="js/main.js"></script>
+  </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,112 +1,128 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>SpotiDeals – Contactez-nous</title>
-  <meta name="description" content="Contactez l'équipe SpotiDeals pour toute question ou assistance concernant l'activation de votre abonnement Spotify Premium.">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="css/style.css">
-</head>
-<body>
-
-  <!-- HEADER -->
-  <header class="header">
-    <div class="container header__inner">
-      <a href="index.html" class="logo">SpotiDeals</a>
-      <nav class="nav">
-        <a href="index.html#features">Fonctionnalités</a>
-        <a href="index.html#pricing">Tarifs</a>
-        <a href="index.html#how">Comment ça marche</a>
-        <a href="index.html#faq">FAQ</a>
-      </nav>
-      <a href="index.html#commande" class="btn btn--sm">Commander</a>
-    </div>
-  </header>
-
-  <section class="faq" id="faq">
-    <div class="container">
-      <h2>🧐 Questions fréquentes</h2>
-
-      <!-- Existing FAQs -->
-      <div class="faq-item">
-        <h4>1) Sera-t-il possible de prolonger cet abonnement ?</h4>
-        <p>Oui, il est possible de renouveler votre abonnement une fois la période de 12 mois terminée.</p>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SpotiDeals – Contactez-nous</title>
+    <meta
+      name="description"
+      content="Contactez SpotiDeals pour toute question sur l'activation de votre Spotify Premium."
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="container header__inner">
+        <a href="index.html" class="logo">SpotiDeals</a>
+        <nav class="nav">
+          <a href="index.html#features">Fonctionnalités</a>
+          <a href="index.html#pricing">Tarifs</a>
+          <a href="index.html#how">Comment ça marche</a>
+          <a href="index.html#faq">FAQ</a>
+        </nav>
+        <a href="index.html#commande" class="btn btn--sm">Commander</a>
       </div>
+    </header>
 
-      <div class="faq-item">
-        <h4>2) Puis-je acheter si j'avais déjà un abonnement actif ?</h4>
-        <p>Oui, vous pouvez commander tant que votre ancien abonnement n'est pas actif au moment de l'achat.</p>
+    <section class="faq" id="faq">
+      <div class="container">
+        <h2>🧐 Questions fréquentes</h2>
+
+        <!-- Existing FAQs -->
+        <div class="faq-item">
+          <h4>1) Sera-t-il possible de prolonger cet abonnement ?</h4>
+          <p>Oui, il est possible de renouveler votre abonnement une fois la période de 12 mois terminée.</p>
+        </div>
+
+        <div class="faq-item">
+          <h4>2) Puis-je acheter si j'avais déjà un abonnement actif ?</h4>
+          <p>Oui, vous pouvez commander tant que votre ancien abonnement n'est pas actif au moment de l'achat.</p>
+        </div>
+
+        <div class="faq-item">
+          <h4>3) Puis-je acheter si mon compte est bloqué pour paiement ?</h4>
+          <p>
+            Oui, nous pouvons toujours activer votre abonnement même si votre compte est bloqué (hors comptes signalés).
+          </p>
+        </div>
+
+        <div class="faq-item">
+          <h4>4) Ai-je besoin d'un proxy ou d'un VPN pour écouter ma musique ?</h4>
+          <p>
+            Non, vous utilisez l'application officielle Spotify dans votre pays sans proxy. (Seule exception :
+            Donetsk/Lougansk/Crimée peuvent nécessiter un proxy.)
+          </p>
+        </div>
+
+        <!-- New FAQ Items -->
+        <div class="faq-item">
+          <h4>5) Combien de temps prend l'activation de mon abonnement ?</h4>
+          <p>L'activation se fait généralement sous 3 à 5 jours ouvrables après la confirmation de votre paiement.</p>
+        </div>
+
+        <div class="faq-item">
+          <h4>6) Quels moyens de paiement acceptez-vous ?</h4>
+          <p>Nous acceptons les cartes bancaires et les cartes cadeaux via PayPal pour un paiement sécurisé.</p>
+        </div>
+
+        <div class="faq-item">
+          <h4>7) Est-ce que je peux utiliser mon abonnement sur plusieurs appareils ?</h4>
+          <p>
+            Oui, votre abonnement Premium individuel vous permet d'utiliser Spotify sur tous vos appareils personnels.
+          </p>
+        </div>
+
+        <div class="faq-item">
+          <h4>8) Que se passe-t-il si je rencontre des problèmes avec mon abonnement ?</h4>
+          <p>
+            Notre support client est disponible 7 jours sur 7 pour vous aider à résoudre tout problème lié à votre
+            abonnement.
+          </p>
+        </div>
+
+        <div class="faq-item">
+          <h4>9) Est-ce que je peux annuler mon abonnement avant la fin des 12 mois ?</h4>
+          <p>
+            L'abonnement est prépayé pour 12 mois et ne peut pas être remboursé. Cependant, vous pouvez toujours
+            utiliser votre compte Spotify normal après la période Premium.
+          </p>
+        </div>
+
+        <div class="faq-item">
+          <h4>10) Comment puis-je vérifier que mon abonnement est bien activé ?</h4>
+          <p>
+            Vous recevrez un e-mail de confirmation une fois l'activation terminée. Vous pouvez également vérifier votre
+            statut Premium directement dans l'application Spotify.
+          </p>
+        </div>
       </div>
+    </section>
 
-      <div class="faq-item">
-        <h4>3) Puis-je acheter si mon compte est bloqué pour paiement ?</h4>
-        <p>Oui, nous pouvons toujours activer votre abonnement même si votre compte est bloqué (hors comptes signalés).</p>
+    <!-- MAIN CONTENT -->
+    <main class="container card">
+      <h1>Contactez-nous</h1>
+      <form action="mailto:contact@spotideals.com" method="post" enctype="text/plain">
+        <label for="name">Votre nom</label>
+        <input type="text" id="name" name="name" required />
+        <label for="email">Votre e-mail</label>
+        <input type="email" id="email" name="email" required />
+        <label for="message">Votre message</label>
+        <textarea id="message" name="message" rows="4" required></textarea>
+        <button type="submit" class="btn">Envoyer</button>
+      </form>
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="footer">
+      <div class="container footer__inner">
+        <div>© 2025 SpotiDeals</div>
+        <nav>
+          <a href="terms.html">CGV</a>
+          <a href="privacy.html">Confidentialité</a>
+          <a href="contact.html">Contact</a>
+        </nav>
       </div>
-
-      <div class="faq-item">
-        <h4>4) Ai-je besoin d'un proxy ou d'un VPN pour écouter ma musique ?</h4>
-        <p>Non, vous utilisez l'application officielle Spotify dans votre pays sans proxy.  
-        (Seule exception : Donetsk/Lougansk/Crimée peuvent nécessiter un proxy.)</p>
-      </div>
-
-      <!-- New FAQ Items -->
-      <div class="faq-item">
-        <h4>5) Combien de temps prend l'activation de mon abonnement ?</h4>
-        <p>L'activation se fait généralement sous 3 à 5 jours ouvrables après la confirmation de votre paiement.</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>6) Quels moyens de paiement acceptez-vous ?</h4>
-        <p>Nous acceptons les cartes bancaires et les cartes cadeaux via PayPal pour un paiement sécurisé.</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>7) Est-ce que je peux utiliser mon abonnement sur plusieurs appareils ?</h4>
-        <p>Oui, votre abonnement Premium individuel vous permet d'utiliser Spotify sur tous vos appareils personnels.</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>8) Que se passe-t-il si je rencontre des problèmes avec mon abonnement ?</h4>
-        <p>Notre support client est disponible 7 jours sur 7 pour vous aider à résoudre tout problème lié à votre abonnement.</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>9) Est-ce que je peux annuler mon abonnement avant la fin des 12 mois ?</h4>
-        <p>L'abonnement est prépayé pour 12 mois et ne peut pas être remboursé. Cependant, vous pouvez toujours utiliser votre compte Spotify normal après la période Premium.</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>10) Comment puis-je vérifier que mon abonnement est bien activé ?</h4>
-        <p>Vous recevrez un e-mail de confirmation une fois l'activation terminée. Vous pouvez également vérifier votre statut Premium directement dans l'application Spotify.</p>
-      </div>
-    </div>
-  </section>
-
-  <!-- MAIN CONTENT -->
-  <main class="container card">
-    <h1>Contactez-nous</h1>
-    <form action="mailto:contact@spotideals.com" method="post" enctype="text/plain">
-      <label for="name">Votre nom</label>
-      <input type="text" id="name" name="name" required>
-      <label for="email">Votre e-mail</label>
-      <input type="email" id="email" name="email" required>
-      <label for="message">Votre message</label>
-      <textarea id="message" name="message" rows="4" required></textarea>
-      <button type="submit" class="btn">Envoyer</button>
-    </form>
-  </main>
-
-  <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container footer__inner">
-      <div>© 2025 SpotiDeals</div>
-      <nav>
-        <a href="terms.html">CGV</a>
-        <a href="privacy.html">Confidentialité</a>
-        <a href="contact.html">Contact</a>
-      </nav>
-    </div>
-  </footer>
-
-</body>
+    </footer>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,719 +1,839 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>SpotiDeals – Pack Activation Spotify Premium 12 mois INDIVIDUEL</title>
-  <meta name="description" content="Rejoignez SpotiDeals pour activer un abonnement Spotify Premium 12 mois INDIVIDUEL à petit prix. Activation rapide, sans VPN.">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-  <link rel="manifest" href="favicon/site.webmanifest">
-  <meta name="theme-color" content="#1DB954">
-  
-  <!-- SEO Meta Tags -->
-  <meta name="keywords" content="Spotify Premium, abonnement Spotify, Spotify 12 mois, activation Spotify, économie Spotify">
-  <meta name="author" content="SpotiDeals">
-  <meta name="robots" content="index, follow">
-  
-  <!-- Open Graph / Social Media -->
-  <meta property="og:title" content="SpotiDeals – Spotify Premium 12 mois INDIVIDUEL">
-  <meta property="og:description" content="Économisez plus de 50% sur votre abonnement Spotify Premium. Activation rapide, sans VPN.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://spotideals.com">
-  
-  <!-- Structured Data -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Product",
-    "name": "Spotify Premium 12 mois INDIVIDUEL",
-    "description": "Pack Activation Spotify Premium 12 mois INDIVIDUEL",
-    "offers": {
-      "@type": "Offer",
-      "price": "82.62",
-      "priceCurrency": "CAD"
-    }
-  }
-  </script>
-  
-  <!-- Montserrat + CSS -->
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SpotiDeals – Pack Activation Spotify Premium 12 mois INDIVIDUEL</title>
+    <meta name="description" content="Activez Spotify Premium 12 mois à petit prix avec SpotiDeals, sans VPN." />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <!-- HEADER -->
-  <header class="header">
-    <div class="container header__inner">
-      <a href="index.html" class="logo">
-        <img src="images/logo.png" alt="SpotiDeals Logo" class="logo-img">
-        SpotiDeals
-      </a>
-      <button class="mobile-menu-btn" aria-label="Menu">
-        <span></span>
-        <span></span>
-        <span></span>
-      </button>
-      <nav class="nav">
-        <a href="#features">Fonctionnalités</a>
-        <a href="#pricing">Offre</a>
-        <a href="#how">Comment ça marche</a>
-        <a href="#faq">FAQ</a>
-      </nav>
-      <a href="#commande" class="btn btn--sm">Commander</a>
-    </div>
-  </header>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="favicon/site.webmanifest" />
+    <meta name="theme-color" content="#1DB954" />
 
-  <!-- Cookie Consent Banner -->
-  <div id="cookie-consent" class="cookie-consent">
-    <div class="cookie-content">
-      <p>Nous utilisons des cookies pour améliorer votre expérience. En continuant à utiliser ce site, vous acceptez notre utilisation des cookies.</p>
-      <div class="cookie-buttons">
-        <button id="accept-cookies" class="btn btn--sm">Accepter</button>
-        <button id="reject-cookies" class="btn btn--sm btn--outline">Refuser</button>
-      </div>
-    </div>
-  </div>
+    <!-- SEO Meta Tags -->
+    <meta
+      name="keywords"
+      content="Spotify Premium, abonnement Spotify, Spotify 12 mois, activation Spotify, économie Spotify"
+    />
+    <meta name="author" content="SpotiDeals" />
+    <meta name="robots" content="index, follow" />
 
-  <!-- Loading Overlay -->
-  <div id="loading-overlay" class="loading-overlay">
-    <div class="spinner"></div>
-    <p>Chargement en cours...</p>
-  </div>
+    <!-- Open Graph / Social Media -->
+    <meta property="og:title" content="SpotiDeals – Spotify Premium 12 mois INDIVIDUEL" />
+    <meta
+      property="og:description"
+      content="Économisez plus de 50% sur votre abonnement Spotify Premium. Activation rapide, sans VPN."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://spotideals.com" />
 
-  <!-- Progress Bar -->
-  <div id="activation-progress" class="activation-progress">
-    <div class="progress-bar-bg"></div>
-    <div class="progress-bar-fill" id="progress-bar-fill"></div>
-    <div class="progress-steps">
-      <div class="step active" data-step="1">
-        <span class="step-number">1</span>
-        <span class="step-text">Commande</span>
-        <span class="step-details">Remplissez le formulaire</span>
-        <span class="step-image">🛒</span>
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Spotify Premium 12 mois INDIVIDUEL",
+        "description": "Pack Activation Spotify Premium 12 mois INDIVIDUEL",
+        "offers": {
+          "@type": "Offer",
+          "price": "82.62",
+          "priceCurrency": "CAD"
+        }
+      }
+    </script>
+
+    <!-- Montserrat + CSS -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="container header__inner">
+        <a href="index.html" class="logo">
+          <img src="images/logo.png" alt="SpotiDeals Logo" class="logo-img" />
+          SpotiDeals
+        </a>
+        <button class="mobile-menu-btn" aria-label="Menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav class="nav">
+          <a href="#features">Fonctionnalités</a>
+          <a href="#pricing">Offre</a>
+          <a href="#how">Comment ça marche</a>
+          <a href="#faq">FAQ</a>
+        </nav>
+        <a href="#commande" class="btn btn--sm">Commander</a>
       </div>
-      <div class="step" data-step="2">
-        <span class="step-number">2</span>
-        <span class="step-text">Paiement</span>
-        <span class="step-details">Payez via PayPal</span>
-        <span class="step-image">💳</span>
-      </div>
-      <div class="step" data-step="3">
-        <span class="step-number">3</span>
-        <span class="step-text">Vérification</span>
-        <span class="step-details">Confirmation des données</span>
-        <span class="step-image">🔍</span>
-      </div>
-      <div class="step" data-step="4">
-        <span class="step-number">4</span>
-        <span class="step-text">Activation</span>
-        <span class="step-details">Achat du Premium</span>
-        <span class="step-image">⚡</span>
-      </div>
-      <div class="step" data-step="5">
-        <span class="step-number">5</span>
-        <span class="step-text">Confirmation</span>
-        <span class="step-details">Email envoyé et données supprimées de nos systèmes</span>
-        <span class="step-image">✉️</span>
+    </header>
+
+    <!-- Cookie Consent Banner -->
+    <div id="cookie-consent" class="cookie-consent">
+      <div class="cookie-content">
+        <p>
+          Nous utilisons des cookies pour améliorer votre expérience. En continuant à utiliser ce site, vous acceptez
+          notre utilisation des cookies.
+        </p>
+        <div class="cookie-buttons">
+          <button id="accept-cookies" class="btn btn--sm">Accepter</button>
+          <button id="reject-cookies" class="btn btn--sm btn--outline">Refuser</button>
+        </div>
       </div>
     </div>
-  </div>
 
-  <!-- HERO -->
-  <section class="hero" id="hero">
-    <div class="container hero__inner">
-      <div class="hero__copy">
-        <h1>Spotify Premium 12 mois INDIVIDUEL</h1>
-        <p class="hero-intro">SpotiDeals active votre abonnement dans un pays où le prix est inférieur. Vous gardez votre compte et économisez sans VPN.</p>
-        <p class="hero-comparison">Prix officiel&nbsp;: 175,12&nbsp;$ CAD – Avec SpotiDeals&nbsp;: 82,62&nbsp;$ CAD</p>
-        <a href="#commande" class="btn">Je veux économiser</a>
+    <!-- Loading Overlay -->
+    <div id="loading-overlay" class="loading-overlay">
+      <div class="spinner"></div>
+      <p>Chargement en cours...</p>
+    </div>
+
+    <!-- Progress Bar -->
+    <div id="activation-progress" class="activation-progress">
+      <div class="progress-bar-bg"></div>
+      <div class="progress-bar-fill" id="progress-bar-fill"></div>
+      <div class="progress-steps">
+        <div class="step active" data-step="1">
+          <span class="step-number">1</span>
+          <span class="step-text">Commande</span>
+          <span class="step-details">Remplissez le formulaire</span>
+          <span class="step-image">🛒</span>
+        </div>
+        <div class="step" data-step="2">
+          <span class="step-number">2</span>
+          <span class="step-text">Paiement</span>
+          <span class="step-details">Payez via PayPal</span>
+          <span class="step-image">💳</span>
+        </div>
+        <div class="step" data-step="3">
+          <span class="step-number">3</span>
+          <span class="step-text">Vérification</span>
+          <span class="step-details">Confirmation des données</span>
+          <span class="step-image">🔍</span>
+        </div>
+        <div class="step" data-step="4">
+          <span class="step-number">4</span>
+          <span class="step-text">Activation</span>
+          <span class="step-details">Achat du Premium</span>
+          <span class="step-image">⚡</span>
+        </div>
+        <div class="step" data-step="5">
+          <span class="step-number">5</span>
+          <span class="step-text">Confirmation</span>
+          <span class="step-details">Email envoyé et données supprimées de nos systèmes</span>
+          <span class="step-image">✉️</span>
+        </div>
       </div>
-      <div class="hero__form">
-        <form id="signup-form" action="#">
-          <input type="email"
-                 id="hero-email"
-                 placeholder="Votre e-mail Spotify"
-                 required
-                 pattern="[^@\s]+@[^@\s]+\.[^@\s]+"
-                 title="Veuillez entrer une adresse e-mail valide !">
-          <input type="password"
-                 id="hero-password"
-                 placeholder="Votre mot de passe Spotify"
-                 required>
-          <button type="submit" class="btn btn--green">Commencer</button>
+    </div>
+
+    <!-- HERO -->
+    <section class="hero" id="hero">
+      <div class="container hero__inner">
+        <div class="hero__copy">
+          <h1>Spotify Premium 12 mois INDIVIDUEL</h1>
+          <p class="hero-intro">
+            SpotiDeals active votre abonnement dans un pays où le prix est inférieur. Vous gardez votre compte et
+            économisez sans VPN.
+          </p>
+          <p class="hero-comparison">
+            Prix officiel&nbsp;: 175,12&nbsp;$ CAD – Avec SpotiDeals&nbsp;: 82,62&nbsp;$ CAD
+          </p>
+          <a href="#commande" class="btn">Je veux économiser</a>
+        </div>
+        <div class="hero__form">
+          <form id="signup-form" action="#">
+            <input
+              type="email"
+              id="hero-email"
+              placeholder="Votre e-mail Spotify"
+              required
+              pattern="[^@\s]+@[^@\s]+\.[^@\s]+"
+              title="Veuillez entrer une adresse e-mail valide !"
+            />
+            <input type="password" id="hero-password" placeholder="Votre mot de passe Spotify" required />
+            <button type="submit" class="btn btn--green">Commencer</button>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- POURQUOI NOUS FAIRE CONFIANCE -->
+    <section class="trust" id="trust">
+      <div class="container">
+        <h2 class="section-title">Pourquoi nous faire confiance ?</h2>
+
+        <!-- Badges de Sécurité -->
+        <div class="trust-badges">
+          <div class="trust-badge">
+            <img src="images/ssl-badge.svg" alt="SSL Sécurisé" class="trust-badge__img" />
+            <h3>SSL Sécurisé</h3>
+            <p>Site protégé par HTTPS</p>
+          </div>
+          <div class="trust-badge">
+            <img src="images/payment-badge.svg" alt="Paiement Sécurisé" class="trust-badge__img" />
+            <h3>Paiement Sécurisé</h3>
+            <p>Transactions protégées par PayPal</p>
+          </div>
+          <div class="trust-badge">
+            <img src="images/privacy-badge.svg" alt="Confidentialité" class="trust-badge__img" />
+            <h3>Confidentialité</h3>
+            <p>Vos données sont supprimées après activation</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- FEATURES – Slider défilant -->
+    <section class="features" id="features">
+      <div class="container">
+        <h2 class="section-title">Pourquoi SpotiDeals ?</h2>
+        <div class="feature-slider">
+          <div class="feature-slide-track">
+            <!-- 8 cartes uniques -->
+            <div class="feature-card">
+              <div class="feature-card__icon">🔥</div>
+              <h3>Prix imbattable</h3>
+              <p>+ 50 % d'économie</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">⚡</div>
+              <h3>Activation rapide</h3>
+              <p>3 à 5 jours ouvrables</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">🌍</div>
+              <h3>Service mondial</h3>
+              <p>Sans VPN</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">💳</div>
+              <h3>Paiement sécurisé</h3>
+              <p>
+                Carte ou Cadeau<br /><span style="font-size: 0.95em">Nous prépayons les 12 mois sur votre compte</span>
+              </p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">🚫</div>
+              <h3>Sans VPN/Proxy</h3>
+              <p>Accès direct, pas de paramétrage supplémentaire.</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">⭐</div>
+              <h3>Support réactif</h3>
+              <p></p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">🎵</div>
+              <h3>Votre propre compte</h3>
+              <p>Écoutez votre musique</p>
+            </div>
+            <!-- répétition pour bouclage -->
+            <div class="feature-card">
+              <div class="feature-card__icon">🔥</div>
+              <h3>Prix imbattable</h3>
+              <p>+ 50 % d'économie</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">⚡</div>
+              <h3>Activation rapide</h3>
+              <p>3 à 5 jours ouvrables</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">🌍</div>
+              <h3>Service mondial</h3>
+              <p>Sans VPN</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">💳</div>
+              <h3>Paiement sécurisé</h3>
+              <p>
+                Carte ou Cadeau<br /><span style="font-size: 0.95em">Nous prépayons les 12 mois sur votre compte</span>
+              </p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">🚫</div>
+              <h3>Sans VPN/Proxy</h3>
+              <p>Accès direct, pas de paramétrage supplémentaire.</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">⭐</div>
+              <h3>Support réactif</h3>
+              <p></p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-card__icon">🎵</div>
+              <h3>Votre propre compte</h3>
+              <p>Écoutez votre musique</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- NOTRE OFFRE UNIQUE -->
+    <section id="pricing" class="pricing animated-section">
+      <div class="container">
+        <h2 class="section-title">Notre offre unique</h2>
+        <div class="grid grid--1">
+          <div class="pricing-card pricing-card--highlight" style="--delay: 0.2s">
+            <h3>Pack 12 mois INDIVIDUEL</h3>
+            <p class="pricing-card__price">82<span class="pricing-card__cents">,62</span> $ CAD</p>
+            <ul class="pricing-card__list">
+              <li>Activation manuelle – Spotify Premium 12 mois</li>
+              <li>Traitement sous 3 à 5 jours ouvrables</li>
+            </ul>
+            <a href="#commande" class="btn">Choisir ce pack</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- COMPARAISON DES PRIX -->
+    <section class="comparison" id="comparison">
+      <div class="container">
+        <h2 class="section-title">Comparatif des Prix</h2>
+        <div class="comparison-grid">
+          <!-- Prix Standard -->
+          <div class="comparison-card comparison-card--standard">
+            <div class="comparison-header">
+              <h3>Prix Standard</h3>
+              <div class="comparison-price">
+                <span class="price-amount">175,12</span>
+                <span class="price-currency">$ CAD</span>
+              </div>
+              <p class="comparison-period">/ 12 mois</p>
+            </div>
+            <ul class="comparison-features">
+              <li class="comparison-feature">
+                <span class="feature-icon">✓</span>
+                <span>Prix standard Spotify</span>
+              </li>
+              <li class="comparison-feature">
+                <span class="feature-icon">✓</span>
+                <span>Paiement mensuel</span>
+              </li>
+              <li class="comparison-feature">
+                <span class="feature-icon">✓</span>
+                <span>Accès Premium</span>
+              </li>
+              <li class="comparison-feature disabled">
+                <span class="feature-icon">×</span>
+                <span>Économie</span>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Notre Offre -->
+          <div class="comparison-card comparison-card--highlight">
+            <div class="comparison-badge">Meilleur Choix</div>
+            <div class="comparison-header">
+              <h3>Notre Offre</h3>
+              <div class="comparison-price">
+                <span class="price-amount">82,62</span>
+                <span class="price-currency">$ CAD</span>
+              </div>
+              <p class="comparison-period">/ 12 mois</p>
+            </div>
+            <ul class="comparison-features">
+              <li class="comparison-feature">
+                <span class="feature-icon">✓</span>
+                <span>Prix réduit de 53%</span>
+              </li>
+              <li class="comparison-feature">
+                <span class="feature-icon">✓</span>
+                <span>Paiement unique</span>
+              </li>
+              <li class="comparison-feature">
+                <span class="feature-icon">✓</span>
+                <span>Accès Premium</span>
+              </li>
+              <li class="comparison-feature">
+                <span class="feature-icon">✓</span>
+                <span>Économie de 92,50$</span>
+              </li>
+            </ul>
+            <a href="#commande" class="btn">Choisir cette offre</a>
+          </div>
+        </div>
+
+        <!-- Économie Calculée -->
+        <div class="savings-calculator">
+          <h3>Votre Économie</h3>
+          <div class="savings-grid">
+            <div class="savings-item">
+              <span class="savings-label">Prix Standard Spotify</span>
+              <span class="savings-value savings-value--original">175,12$</span>
+              <span class="savings-period">/ 12 mois</span>
+            </div>
+            <div class="savings-item">
+              <span class="savings-label">Notre Prix</span>
+              <span class="savings-value savings-value--discount">82,62$</span>
+              <span class="savings-period">/ 12 mois</span>
+            </div>
+            <div class="savings-item savings-total">
+              <span class="savings-label">Votre Économie</span>
+              <span class="savings-value savings-value--total">92,50$</span>
+              <span class="savings-badge">53% d'économie</span>
+            </div>
+          </div>
+          <div class="savings-features">
+            <div class="savings-feature">
+              <span class="feature-icon">💰</span>
+              <span>Économisez plus de 90$ par an</span>
+            </div>
+            <div class="savings-feature">
+              <span class="feature-icon">⚡</span>
+              <span>Activation rapide sous 3 à 5 jours ouvrables</span>
+            </div>
+            <div class="savings-feature">
+              <span class="feature-icon">🛡️</span>
+              <span>Paiement sécurisé via PayPal</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- HOW IT WORKS -->
+    <section class="how" id="how">
+      <div class="container">
+        <h2 class="section-title">Comment ça marche ?</h2>
+        <div class="grid grid--3">
+          <div class="how-step">
+            <div class="how-step__num">1</div>
+            <h4>Préparation</h4>
+            <p>Changez votre mot de passe Spotify avant de commencer. Cela garantit la sécurité de votre compte.</p>
+          </div>
+          <div class="how-step">
+            <div class="how-step__num">2</div>
+            <h4>Commande</h4>
+            <p>
+              Entrez votre email et mot de passe Spotify. Nous utilisons ces informations uniquement pour l'activation.
+            </p>
+          </div>
+          <div class="how-step">
+            <div class="how-step__num">3</div>
+            <h4>Paiement</h4>
+            <p>Payez 82,62$ CAD via PayPal. Le paiement est sécurisé et instantané.</p>
+          </div>
+          <div class="how-step">
+            <div class="how-step__num">4</div>
+            <h4>Activation</h4>
+            <p>Nous nous connectons à votre compte pour effectuer l'achat officiel de 12 mois.</p>
+          </div>
+          <div class="how-step">
+            <div class="how-step__num">5</div>
+            <h4>Confirmation</h4>
+            <p>Vous recevez une confirmation par email et vos données seront supprimées de nos systèmes.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- LÉGALITÉ ET RESPONSABILITÉ -->
+    <section class="legal" id="legal">
+      <div class="container">
+        <h2 class="section-title">Légalité et Responsabilité</h2>
+        <div class="legal-grid">
+          <div class="legal-item">
+            <div class="legal-icon">⚖️</div>
+            <div class="legal-text">
+              <h3>Service Légal</h3>
+              <p>
+                Notre service consiste uniquement à effectuer un achat officiel de Spotify Premium dans un pays où les
+                prix sont plus avantageux. Il s'agit d'un achat légitime via les canaux officiels de Spotify.
+              </p>
+            </div>
+          </div>
+          <div class="legal-item">
+            <div class="legal-icon">🌍</div>
+            <div class="legal-text">
+              <h3>Différence de Prix</h3>
+              <p>
+                Nous utilisons simplement la différence de prix entre les pays, comme le font de nombreux services de
+                voyage et d'achat international. C'est une pratique commerciale courante et légale.
+              </p>
+            </div>
+          </div>
+          <div class="legal-item">
+            <div class="legal-icon">📜</div>
+            <div class="legal-text">
+              <h3>Conformité Spotify</h3>
+              <p>
+                L'achat est effectué selon les conditions d'utilisation de Spotify. Nous n'utilisons aucun moyen de
+                contournement ou de modification du service.
+              </p>
+            </div>
+          </div>
+          <div class="legal-item">
+            <div class="legal-icon">⚠️</div>
+            <div class="legal-text">
+              <h3>Clause de Non-Responsabilité</h3>
+              <p>
+                Nous ne sommes pas responsables des décisions de Spotify concernant votre compte. Nous vendons
+                uniquement notre service d'activation et n'avons aucun contrôle sur les politiques ou décisions de
+                Spotify.
+              </p>
+            </div>
+          </div>
+          <div class="legal-item">
+            <div class="legal-icon">🛡️</div>
+            <div class="legal-text">
+              <h3>Protection du Service</h3>
+              <p>
+                En utilisant notre service, vous acceptez que nous ne pouvons être tenus responsables de toute action de
+                Spotify, y compris mais sans s'y limiter : suspension de compte, bannissement, ou modification des
+                conditions d'utilisation.
+              </p>
+            </div>
+          </div>
+          <div class="legal-item">
+            <div class="legal-icon">📝</div>
+            <div class="legal-text">
+              <h3>Acceptation des Risques</h3>
+              <p>
+                En commandant, vous reconnaissez être conscient des risques potentiels liés à l'utilisation de notre
+                service et acceptez que nous ne pouvons être tenus responsables des décisions de Spotify.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- FAQ – Accordéon animé -->
+    <section id="faq" class="faq animated-section">
+      <div class="container">
+        <h2 class="section-title">Questions fréquentes</h2>
+        <div class="faq-item" style="--delay: 0.1s">
+          <h4>1) Prolonger l'abonnement ?</h4>
+          <p>Oui, vous pouvez renouveler à tout moment.</p>
+        </div>
+        <div class="faq-item" style="--delay: 0.2s">
+          <h4>2) Déjà abonné ?</h4>
+          <p>Oui, à condition que l'ancien soit inactif.</p>
+        </div>
+        <div class="faq-item" style="--delay: 0.3s">
+          <h4>3) Compte bloqué ?</h4>
+          <p>Oui, hors comptes signalés.</p>
+        </div>
+        <div class="faq-item" style="--delay: 0.4s">
+          <h4>4) Besoin de VPN ?</h4>
+          <p>Non, fonctionne sans VPN.</p>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- SECTION IMPORTANTE -->
+    <section class="important" id="important">
+      <div class="container">
+        <h2 class="section-title">Points clés à retenir</h2>
+        <ul class="important-list">
+          <li>
+            <span class="important-icon">🔒</span>
+            <strong>Sécurité des données</strong><br />
+            Pour votre sécurité, nous vous recommandons de :<br />
+            - Utiliser un mot de passe temporaire unique pour cette commande<br />
+            - Changer votre mot de passe avant et après l'activation<br />
+            - Ne jamais partager votre mot de passe habituel
+          </li>
+          <li>
+            <span class="important-icon">⏱️</span>
+            <strong>Délais garantis</strong><br />
+            Traitement de la commande peut prendre 3 à 5 jours ouvrables.<br />
+            (Vous pouvez continuer à utiliser votre compte pendant ce délai)
+          </li>
+          <li>
+            <span class="important-icon">💰</span>
+            <strong>Économies réelles</strong><br />
+            Notre prix de service est de 82,62 $ CAD TOUS FRAIS INCLUS pour l'activation de votre compte 12 mois
+            Premium, soit plus de 50 % d'économie.
+          </li>
+          <li>
+            <span class="important-icon">❗</span>
+            <strong>Pas de revente</strong><br />
+            Service d'activation uniquement, non destiné à la revente.
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Theme Toggle Button -->
+    <button id="theme-toggle" class="theme-toggle" aria-label="Changer le thème">
+      <svg class="sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="5" />
+        <line x1="12" y1="1" x2="12" y2="3" />
+        <line x1="12" y1="21" x2="12" y2="23" />
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+        <line x1="1" y1="12" x2="3" y2="12" />
+        <line x1="21" y1="12" x2="23" y2="12" />
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+      </svg>
+      <svg class="moon-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </svg>
+    </button>
+
+    <div class="divider divider--slant"></div>
+
+    <!-- COMMANDE -->
+    <section class="commande card" id="commande">
+      <div class="container">
+        <h2 class="section-title">🛒 Commander maintenant</h2>
+
+        <!-- Informations de Sécurité -->
+        <div class="security-notice">
+          <h3>⚠️ Important - Sécurité du Compte</h3>
+          <p>Pour garantir la sécurité de votre compte, veuillez suivre ces étapes :</p>
+          <ol>
+            <li>Changez votre mot de passe Spotify <strong>avant</strong> de commencer la commande</li>
+            <li>Utilisez un mot de passe temporaire que vous pourrez changer après l'activation</li>
+            <li>Ne partagez jamais votre mot de passe habituel</li>
+          </ol>
+        </div>
+
+        <!-- Formulaire de Commande -->
+        <form id="order-form" class="order-form">
+          <div class="form-group">
+            <label for="cmd-email">📧 E-mail Spotify</label>
+            <input
+              type="email"
+              id="cmd-email"
+              placeholder="exemple@mail.com"
+              required
+              pattern="[^@\s]+@[^@\s]+\.[^@\s]+"
+            />
+          </div>
+
+          <div class="form-group">
+            <label for="cmd-password">🔑 Mot de passe Spotify</label>
+            <input type="password" id="cmd-password" placeholder="Votre mot de passe temporaire" required />
+            <small class="form-hint"
+              >Utilisez un mot de passe temporaire que vous pourrez changer après l'activation</small
+            >
+          </div>
+
+          <!-- Cases à cocher de consentement -->
+          <div class="consent-checks">
+            <div class="checkbox-group">
+              <input type="checkbox" id="consent-password" required />
+              <label for="consent-password">J'ai changé mon mot de passe Spotify avant de commencer</label>
+            </div>
+
+            <div class="checkbox-group">
+              <input type="checkbox" id="consent-process" required />
+              <label for="consent-process"
+                >Je comprends que vous vous connecterez temporairement à mon compte pour l'activation</label
+              >
+            </div>
+
+            <div class="checkbox-group">
+              <input type="checkbox" id="consent-delete" required />
+              <label for="consent-delete"
+                >Je comprends que toutes mes informations seront supprimées après l'activation</label
+              >
+            </div>
+
+            <div class="checkbox-group">
+              <input type="checkbox" id="consent-change-password" required />
+              <label for="consent-change-password">Je m'engage à changer mon mot de passe après l'activation</label>
+            </div>
+
+            <div class="checkbox-group">
+              <input type="checkbox" id="consent-responsibility" required />
+              <label for="consent-responsibility"
+                >Je comprends que vous n'êtes pas responsable des décisions de Spotify concernant mon compte</label
+              >
+            </div>
+
+            <div class="checkbox-group">
+              <input type="checkbox" id="consent-active" required />
+              <label for="consent-active">Mon abonnement ne doit pas être actif au moment de l'achat</label>
+            </div>
+
+            <div class="checkbox-group">
+              <input type="checkbox" id="consent-no-refund" required />
+              <label for="consent-no-refund"
+                >Je comprends qu'il n'y aura pas de remboursement si l'activation est réalisée</label
+              >
+            </div>
+          </div>
+
+          <button id="order-btn" class="btn" disabled>▶️ Passer au paiement</button>
         </form>
-      </div>
-    </div>
-  </section>
 
-  <div class="divider divider--slant"></div>
-
-  <!-- POURQUOI NOUS FAIRE CONFIANCE -->
-  <section class="trust" id="trust">
-    <div class="container">
-      <h2 class="section-title">Pourquoi nous faire confiance ?</h2>
-      
-      <!-- Badges de Sécurité -->
-      <div class="trust-badges">
-        <div class="trust-badge">
-          <img src="images/ssl-badge.svg" alt="SSL Sécurisé" class="trust-badge__img">
-          <h3>SSL Sécurisé</h3>
-          <p>Site protégé par HTTPS</p>
-        </div>
-        <div class="trust-badge">
-          <img src="images/payment-badge.svg" alt="Paiement Sécurisé" class="trust-badge__img">
-          <h3>Paiement Sécurisé</h3>
-          <p>Transactions protégées par PayPal</p>
-        </div>
-        <div class="trust-badge">
-          <img src="images/privacy-badge.svg" alt="Confidentialité" class="trust-badge__img">
-          <h3>Confidentialité</h3>
-          <p>Vos données sont supprimées après activation</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- FEATURES – Slider défilant -->
-  <section class="features" id="features">
-    <div class="container">
-      <h2 class="section-title">Pourquoi SpotiDeals ?</h2>
-      <div class="feature-slider">
-        <div class="feature-slide-track">
-          <!-- 8 cartes uniques -->
-          <div class="feature-card"><div class="feature-card__icon">🔥</div><h3>Prix imbattable</h3><p>+ 50 % d'économie</p></div>
-          <div class="feature-card"><div class="feature-card__icon">⚡</div><h3>Activation rapide</h3><p>3 à 5 jours ouvrables</p></div>
-          <div class="feature-card"><div class="feature-card__icon">🌍</div><h3>Service mondial</h3><p>Sans VPN</p></div>
-          <div class="feature-card"><div class="feature-card__icon">💳</div><h3>Paiement sécurisé</h3><p>Carte ou Cadeau<br><span style='font-size:0.95em;'>Nous prépayons les 12 mois sur votre compte</span></p></div>
-          <div class="feature-card"><div class="feature-card__icon">🚫</div><h3>Sans VPN/Proxy</h3><p>Accès direct, pas de paramétrage supplémentaire.</p></div>
-          <div class="feature-card"><div class="feature-card__icon">⭐</div><h3>Support réactif</h3><p></p></div>
-          <div class="feature-card"><div class="feature-card__icon">🎵</div><h3>Votre propre compte</h3><p>Écoutez votre musique</p></div>
-          <!-- répétition pour bouclage -->
-          <div class="feature-card"><div class="feature-card__icon">🔥</div><h3>Prix imbattable</h3><p>+ 50 % d'économie</p></div>
-          <div class="feature-card"><div class="feature-card__icon">⚡</div><h3>Activation rapide</h3><p>3 à 5 jours ouvrables</p></div>
-          <div class="feature-card"><div class="feature-card__icon">🌍</div><h3>Service mondial</h3><p>Sans VPN</p></div>
-          <div class="feature-card"><div class="feature-card__icon">💳</div><h3>Paiement sécurisé</h3><p>Carte ou Cadeau<br><span style='font-size:0.95em;'>Nous prépayons les 12 mois sur votre compte</span></p></div>
-          <div class="feature-card"><div class="feature-card__icon">🚫</div><h3>Sans VPN/Proxy</h3><p>Accès direct, pas de paramétrage supplémentaire.</p></div>
-          <div class="feature-card"><div class="feature-card__icon">⭐</div><h3>Support réactif</h3><p></p></div>
-          <div class="feature-card"><div class="feature-card__icon">🎵</div><h3>Votre propre compte</h3><p>Écoutez votre musique</p></div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- NOTRE OFFRE UNIQUE -->
-  <section id="pricing" class="pricing animated-section">
-    <div class="container">
-      <h2 class="section-title">Notre offre unique</h2>
-      <div class="grid grid--1">
-        <div class="pricing-card pricing-card--highlight" style="--delay:0.2s">
-          <h3>Pack 12 mois INDIVIDUEL</h3>
-          <p class="pricing-card__price">82<span class="pricing-card__cents">,62</span> $ CAD</p>
-          <ul class="pricing-card__list">
-            <li>Activation manuelle – Spotify Premium 12 mois</li>
-            <li>Traitement sous 3 à 5 jours ouvrables</li>
-          </ul>
-          <a href="#commande" class="btn">Choisir ce pack</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- COMPARAISON DES PRIX -->
-  <section class="comparison" id="comparison">
-    <div class="container">
-      <h2 class="section-title">Comparatif des Prix</h2>
-      <div class="comparison-grid">
-        <!-- Prix Standard -->
-        <div class="comparison-card comparison-card--standard">
-          <div class="comparison-header">
-            <h3>Prix Standard</h3>
-            <div class="comparison-price">
-              <span class="price-amount">175,12</span>
-              <span class="price-currency">$ CAD</span>
-            </div>
-            <p class="comparison-period">/ 12 mois</p>
+        <!-- Section de suivi de commande -->
+        <div class="order-tracking" style="display: none">
+          <h3>Suivi de commande</h3>
+          <div class="tracking-form">
+            <input type="text" id="order-number-inline" placeholder="Numéro de commande" required />
+            <button type="button" class="btn" id="track-order-btn-inline">Suivre ma commande</button>
           </div>
-          <ul class="comparison-features">
-            <li class="comparison-feature">
-              <span class="feature-icon">✓</span>
-              <span>Prix standard Spotify</span>
-            </li>
-            <li class="comparison-feature">
-              <span class="feature-icon">✓</span>
-              <span>Paiement mensuel</span>
-            </li>
-            <li class="comparison-feature">
-              <span class="feature-icon">✓</span>
-              <span>Accès Premium</span>
-            </li>
-            <li class="comparison-feature disabled">
-              <span class="feature-icon">×</span>
-              <span>Économie</span>
-            </li>
-          </ul>
-        </div>
-
-        <!-- Notre Offre -->
-        <div class="comparison-card comparison-card--highlight">
-          <div class="comparison-badge">Meilleur Choix</div>
-          <div class="comparison-header">
-            <h3>Notre Offre</h3>
-            <div class="comparison-price">
-              <span class="price-amount">82,62</span>
-              <span class="price-currency">$ CAD</span>
-            </div>
-            <p class="comparison-period">/ 12 mois</p>
-          </div>
-          <ul class="comparison-features">
-            <li class="comparison-feature">
-              <span class="feature-icon">✓</span>
-              <span>Prix réduit de 53%</span>
-            </li>
-            <li class="comparison-feature">
-              <span class="feature-icon">✓</span>
-              <span>Paiement unique</span>
-            </li>
-            <li class="comparison-feature">
-              <span class="feature-icon">✓</span>
-              <span>Accès Premium</span>
-            </li>
-            <li class="comparison-feature">
-              <span class="feature-icon">✓</span>
-              <span>Économie de 92,50$</span>
-            </li>
-          </ul>
-          <a href="#commande" class="btn">Choisir cette offre</a>
-        </div>
-      </div>
-
-      <!-- Économie Calculée -->
-      <div class="savings-calculator">
-        <h3>Votre Économie</h3>
-        <div class="savings-grid">
-          <div class="savings-item">
-            <span class="savings-label">Prix Standard Spotify</span>
-            <span class="savings-value savings-value--original">175,12$</span>
-            <span class="savings-period">/ 12 mois</span>
-          </div>
-          <div class="savings-item">
-            <span class="savings-label">Notre Prix</span>
-            <span class="savings-value savings-value--discount">82,62$</span>
-            <span class="savings-period">/ 12 mois</span>
-          </div>
-          <div class="savings-item savings-total">
-            <span class="savings-label">Votre Économie</span>
-            <span class="savings-value savings-value--total">92,50$</span>
-            <span class="savings-badge">53% d'économie</span>
-          </div>
-        </div>
-        <div class="savings-features">
-          <div class="savings-feature">
-            <span class="feature-icon">💰</span>
-            <span>Économisez plus de 90$ par an</span>
-          </div>
-          <div class="savings-feature">
-            <span class="feature-icon">⚡</span>
-            <span>Activation rapide sous 3 à 5 jours ouvrables</span>
-          </div>
-          <div class="savings-feature">
-            <span class="feature-icon">🛡️</span>
-            <span>Paiement sécurisé via PayPal</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- HOW IT WORKS -->
-  <section class="how" id="how">
-    <div class="container">
-      <h2 class="section-title">Comment ça marche ?</h2>
-      <div class="grid grid--3">
-        <div class="how-step">
-          <div class="how-step__num">1</div>
-          <h4>Préparation</h4>
-          <p>Changez votre mot de passe Spotify avant de commencer. Cela garantit la sécurité de votre compte.</p>
-        </div>
-        <div class="how-step">
-          <div class="how-step__num">2</div>
-          <h4>Commande</h4>
-          <p>Entrez votre email et mot de passe Spotify. Nous utilisons ces informations uniquement pour l'activation.</p>
-        </div>
-        <div class="how-step">
-          <div class="how-step__num">3</div>
-          <h4>Paiement</h4>
-          <p>Payez 82,62$ CAD via PayPal. Le paiement est sécurisé et instantané.</p>
-        </div>
-        <div class="how-step">
-          <div class="how-step__num">4</div>
-          <h4>Activation</h4>
-          <p>Nous nous connectons à votre compte pour effectuer l'achat officiel de 12 mois.</p>
-        </div>
-        <div class="how-step">
-          <div class="how-step__num">5</div>
-          <h4>Confirmation</h4>
-          <p>Vous recevez une confirmation par email et vos données seront supprimées de nos systèmes.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- LÉGALITÉ ET RESPONSABILITÉ -->
-  <section class="legal" id="legal">
-    <div class="container">
-      <h2 class="section-title">Légalité et Responsabilité</h2>
-      <div class="legal-grid">
-        <div class="legal-item">
-          <div class="legal-icon">⚖️</div>
-          <div class="legal-text">
-            <h3>Service Légal</h3>
-            <p>Notre service consiste uniquement à effectuer un achat officiel de Spotify Premium dans un pays où les prix sont plus avantageux. Il s'agit d'un achat légitime via les canaux officiels de Spotify.</p>
-          </div>
-        </div>
-        <div class="legal-item">
-          <div class="legal-icon">🌍</div>
-          <div class="legal-text">
-            <h3>Différence de Prix</h3>
-            <p>Nous utilisons simplement la différence de prix entre les pays, comme le font de nombreux services de voyage et d'achat international. C'est une pratique commerciale courante et légale.</p>
-          </div>
-        </div>
-        <div class="legal-item">
-          <div class="legal-icon">📜</div>
-          <div class="legal-text">
-            <h3>Conformité Spotify</h3>
-            <p>L'achat est effectué selon les conditions d'utilisation de Spotify. Nous n'utilisons aucun moyen de contournement ou de modification du service.</p>
-          </div>
-        </div>
-        <div class="legal-item">
-          <div class="legal-icon">⚠️</div>
-          <div class="legal-text">
-            <h3>Clause de Non-Responsabilité</h3>
-            <p>Nous ne sommes pas responsables des décisions de Spotify concernant votre compte. Nous vendons uniquement notre service d'activation et n'avons aucun contrôle sur les politiques ou décisions de Spotify.</p>
-          </div>
-        </div>
-        <div class="legal-item">
-          <div class="legal-icon">🛡️</div>
-          <div class="legal-text">
-            <h3>Protection du Service</h3>
-            <p>En utilisant notre service, vous acceptez que nous ne pouvons être tenus responsables de toute action de Spotify, y compris mais sans s'y limiter : suspension de compte, bannissement, ou modification des conditions d'utilisation.</p>
-          </div>
-        </div>
-        <div class="legal-item">
-          <div class="legal-icon">📝</div>
-          <div class="legal-text">
-            <h3>Acceptation des Risques</h3>
-            <p>En commandant, vous reconnaissez être conscient des risques potentiels liés à l'utilisation de notre service et acceptez que nous ne pouvons être tenus responsables des décisions de Spotify.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- FAQ – Accordéon animé -->
-  <section id="faq" class="faq animated-section">
-    <div class="container">
-      <h2 class="section-title">Questions fréquentes</h2>
-      <div class="faq-item" style="--delay:0.1s"><h4>1) Prolonger l'abonnement ?</h4><p>Oui, vous pouvez renouveler à tout moment.</p></div>
-      <div class="faq-item" style="--delay:0.2s"><h4>2) Déjà abonné ?</h4><p>Oui, à condition que l'ancien soit inactif.</p></div>
-      <div class="faq-item" style="--delay:0.3s"><h4>3) Compte bloqué ?</h4><p>Oui, hors comptes signalés.</p></div>
-      <div class="faq-item" style="--delay:0.4s"><h4>4) Besoin de VPN ?</h4><p>Non, fonctionne sans VPN.</p></div>
-    </div>
-  </section>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- SECTION IMPORTANTE -->
-  <section class="important" id="important">
-    <div class="container">
-      <h2 class="section-title">Points clés à retenir</h2>
-      <ul class="important-list">
-        <li>
-          <span class="important-icon">🔒</span>
-          <strong>Sécurité des données</strong><br>
-          Pour votre sécurité, nous vous recommandons de :<br>
-          - Utiliser un mot de passe temporaire unique pour cette commande<br>
-          - Changer votre mot de passe avant et après l'activation<br>
-          - Ne jamais partager votre mot de passe habituel
-        </li>
-        <li>
-          <span class="important-icon">⏱️</span>
-          <strong>Délais garantis</strong><br>
-          Traitement de la commande peut prendre 3 à 5 jours ouvrables.<br>
-          (Vous pouvez continuer à utiliser votre compte pendant ce délai)
-        </li>
-        <li>
-          <span class="important-icon">💰</span>
-          <strong>Économies réelles</strong><br>
-          Notre prix de service est de 82,62 $ CAD TOUS FRAIS INCLUS pour l'activation de votre compte 12 mois Premium, soit plus de 50 % d'économie.
-        </li>
-        <li>
-          <span class="important-icon">❗</span>
-          <strong>Pas de revente</strong><br>
-          Service d'activation uniquement, non destiné à la revente.
-        </li>
-      </ul>
-    </div>
-  </section>
-
-  <!-- Theme Toggle Button -->
-  <button id="theme-toggle" class="theme-toggle" aria-label="Changer le thème">
-    <svg class="sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="5"/>
-      <line x1="12" y1="1" x2="12" y2="3"/>
-      <line x1="12" y1="21" x2="12" y2="23"/>
-      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-      <line x1="1" y1="12" x2="3" y2="12"/>
-      <line x1="21" y1="12" x2="23" y2="12"/>
-      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-    </svg>
-    <svg class="moon-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-    </svg>
-  </button>
-
-  <div class="divider divider--slant"></div>
-
-  <!-- COMMANDE -->
-  <section class="commande card" id="commande">
-    <div class="container">
-      <h2 class="section-title">🛒 Commander maintenant</h2>
-      
-      <!-- Informations de Sécurité -->
-      <div class="security-notice">
-        <h3>⚠️ Important - Sécurité du Compte</h3>
-        <p>Pour garantir la sécurité de votre compte, veuillez suivre ces étapes :</p>
-        <ol>
-          <li>Changez votre mot de passe Spotify <strong>avant</strong> de commencer la commande</li>
-          <li>Utilisez un mot de passe temporaire que vous pourrez changer après l'activation</li>
-          <li>Ne partagez jamais votre mot de passe habituel</li>
-        </ol>
-      </div>
-
-      <!-- Formulaire de Commande -->
-      <form id="order-form" class="order-form">
-        <div class="form-group">
-          <label for="cmd-email">📧 E-mail Spotify</label>
-          <input type="email" id="cmd-email" placeholder="exemple@mail.com" required pattern="[^@\s]+@[^@\s]+\.[^@\s]+">
-        </div>
-
-        <div class="form-group">
-          <label for="cmd-password">🔑 Mot de passe Spotify</label>
-          <input type="password" id="cmd-password" placeholder="Votre mot de passe temporaire" required>
-          <small class="form-hint">Utilisez un mot de passe temporaire que vous pourrez changer après l'activation</small>
-        </div>
-
-        <!-- Cases à cocher de consentement -->
-        <div class="consent-checks">
-          <div class="checkbox-group">
-            <input type="checkbox" id="consent-password" required>
-            <label for="consent-password">J'ai changé mon mot de passe Spotify avant de commencer</label>
-          </div>
-
-          <div class="checkbox-group">
-            <input type="checkbox" id="consent-process" required>
-            <label for="consent-process">Je comprends que vous vous connecterez temporairement à mon compte pour l'activation</label>
-          </div>
-
-          <div class="checkbox-group">
-            <input type="checkbox" id="consent-delete" required>
-            <label for="consent-delete">Je comprends que toutes mes informations seront supprimées après l'activation</label>
-          </div>
-
-          <div class="checkbox-group">
-            <input type="checkbox" id="consent-change-password" required>
-            <label for="consent-change-password">Je m'engage à changer mon mot de passe après l'activation</label>
-          </div>
-
-          <div class="checkbox-group">
-            <input type="checkbox" id="consent-responsibility" required>
-            <label for="consent-responsibility">Je comprends que vous n'êtes pas responsable des décisions de Spotify concernant mon compte</label>
-          </div>
-
-          <div class="checkbox-group">
-            <input type="checkbox" id="consent-active" required>
-            <label for="consent-active">Mon abonnement ne doit pas être actif au moment de l'achat</label>
-          </div>
-
-          <div class="checkbox-group">
-            <input type="checkbox" id="consent-no-refund" required>
-            <label for="consent-no-refund">Je comprends qu'il n'y aura pas de remboursement si l'activation est réalisée</label>
-          </div>
-        </div>
-
-        <button id="order-btn" class="btn" disabled>▶️ Passer au paiement</button>
-      </form>
-
-      <!-- Section de suivi de commande -->
-      <div class="order-tracking" style="display: none;">
-        <h3>Suivi de commande</h3>
-        <div class="tracking-form">
-          <input type="text" id="order-number-inline" placeholder="Numéro de commande" required>
-          <button type="button" class="btn" id="track-order-btn-inline">Suivre ma commande</button>
-        </div>
-        <div class="tracking-result" style="display: none;">
-          <h4>État de votre commande</h4>
-          <div class="tracking-status">
-            <div class="status-step active">
-              <span class="step-icon">📝</span>
-              <span class="step-text">Commande reçue</span>
-            </div>
-            <div class="status-step">
-              <span class="step-icon">💳</span>
-              <span class="step-text">Paiement confirmé</span>
-            </div>
-            <div class="status-step">
-              <span class="step-icon">⚙️</span>
-              <span class="step-text">En cours de traitement</span>
-            </div>
-            <div class="status-step">
-              <span class="step-icon">✅</span>
-              <span class="step-text">Activation terminée</span>
+          <div class="tracking-result" style="display: none">
+            <h4>État de votre commande</h4>
+            <div class="tracking-status">
+              <div class="status-step active">
+                <span class="step-icon">📝</span>
+                <span class="step-text">Commande reçue</span>
+              </div>
+              <div class="status-step">
+                <span class="step-icon">💳</span>
+                <span class="step-text">Paiement confirmé</span>
+              </div>
+              <div class="status-step">
+                <span class="step-icon">⚙️</span>
+                <span class="step-text">En cours de traitement</span>
+              </div>
+              <div class="status-step">
+                <span class="step-icon">✅</span>
+                <span class="step-text">Activation terminée</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- SUIVI DE COMMANDE -->
-  <section class="order-tracking" id="order-tracking">
-    <div class="container">
-      <h2 class="section-title">Suivi de Commande</h2>
-      
-      <!-- Recherche de commande -->
-      <div class="tracking-search">
-        <div class="tracking-form">
-          <input type="text" id="order-number" placeholder="Numéro de commande" required>
-          <button class="btn" id="track-order-btn">Suivre ma commande</button>
+    <!-- SUIVI DE COMMANDE -->
+    <section class="order-tracking" id="order-tracking">
+      <div class="container">
+        <h2 class="section-title">Suivi de Commande</h2>
+
+        <!-- Recherche de commande -->
+        <div class="tracking-search">
+          <div class="tracking-form">
+            <input type="text" id="order-number" placeholder="Numéro de commande" required />
+            <button class="btn" id="track-order-btn">Suivre ma commande</button>
+          </div>
+          <p class="tracking-hint">Entrez votre numéro de commande reçu par email</p>
         </div>
-        <p class="tracking-hint">Entrez votre numéro de commande reçu par email</p>
+
+        <!-- Résultat du suivi -->
+        <div class="tracking-result" style="display: none">
+          <div class="tracking-header">
+            <div class="tracking-info">
+              <h3>Commande #<span id="result-order-number"></span></h3>
+              <p class="tracking-date">Date: <span id="result-order-date"></span></p>
+            </div>
+            <div class="tracking-status">
+              <span class="status-badge" id="result-order-status">En cours</span>
+            </div>
+          </div>
+
+          <div class="tracking-timeline">
+            <div class="timeline-item completed">
+              <div class="timeline-icon">📝</div>
+              <div class="timeline-content">
+                <h4>Commande reçue</h4>
+                <p>Votre commande a été enregistrée</p>
+                <span class="timeline-date" id="timeline-order-date"></span>
+              </div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-icon">💳</div>
+              <div class="timeline-content">
+                <h4>Paiement confirmé</h4>
+                <p>Votre paiement a été validé</p>
+                <span class="timeline-date" id="timeline-payment-date"></span>
+              </div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-icon">🔍</div>
+              <div class="timeline-content">
+                <h4>Vérification en cours</h4>
+                <p>Nous vérifions vos informations</p>
+                <span class="timeline-date" id="timeline-verification-date"></span>
+              </div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-icon">⚡</div>
+              <div class="timeline-content">
+                <h4>Activation</h4>
+                <p>Activation de votre Premium</p>
+                <span class="timeline-date" id="timeline-activation-date"></span>
+              </div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-icon">✉️</div>
+              <div class="timeline-content">
+                <h4>Confirmation</h4>
+                <p>Email de confirmation envoyé et données supprimées de nos systèmes</p>
+                <span class="timeline-date" id="timeline-confirmation-date"></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="tracking-details">
+            <h4>Détails de la commande</h4>
+            <div class="details-grid">
+              <div class="detail-item">
+                <span class="detail-label">Email Spotify</span>
+                <span class="detail-value" id="result-email"></span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Montant payé</span>
+                <span class="detail-value" id="result-amount"></span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Méthode de paiement</span>
+                <span class="detail-value" id="result-payment-method"></span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Délai estimé</span>
+                <span class="detail-value" id="result-estimated-time"></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="tracking-support">
+            <h4>Besoin d'aide ?</h4>
+            <p>Notre équipe est disponible 24/7 pour vous aider</p>
+            <a href="contact.html" class="btn btn--outline">Contacter le support</a>
+          </div>
+        </div>
       </div>
+    </section>
 
-      <!-- Résultat du suivi -->
-      <div class="tracking-result" style="display: none;">
-        <div class="tracking-header">
-          <div class="tracking-info">
-            <h3>Commande #<span id="result-order-number"></span></h3>
-            <p class="tracking-date">Date: <span id="result-order-date"></span></p>
-          </div>
-          <div class="tracking-status">
-            <span class="status-badge" id="result-order-status">En cours</span>
-          </div>
-        </div>
+    <div class="divider divider--slant"></div>
 
-        <div class="tracking-timeline">
-          <div class="timeline-item completed">
-            <div class="timeline-icon">📝</div>
-            <div class="timeline-content">
-              <h4>Commande reçue</h4>
-              <p>Votre commande a été enregistrée</p>
-              <span class="timeline-date" id="timeline-order-date"></span>
-            </div>
-          </div>
-          <div class="timeline-item">
-            <div class="timeline-icon">💳</div>
-            <div class="timeline-content">
-              <h4>Paiement confirmé</h4>
-              <p>Votre paiement a été validé</p>
-              <span class="timeline-date" id="timeline-payment-date"></span>
-            </div>
-          </div>
-          <div class="timeline-item">
-            <div class="timeline-icon">🔍</div>
-            <div class="timeline-content">
-              <h4>Vérification en cours</h4>
-              <p>Nous vérifions vos informations</p>
-              <span class="timeline-date" id="timeline-verification-date"></span>
-            </div>
-          </div>
-          <div class="timeline-item">
-            <div class="timeline-icon">⚡</div>
-            <div class="timeline-content">
-              <h4>Activation</h4>
-              <p>Activation de votre Premium</p>
-              <span class="timeline-date" id="timeline-activation-date"></span>
-            </div>
-          </div>
-          <div class="timeline-item">
-            <div class="timeline-icon">✉️</div>
-            <div class="timeline-content">
-              <h4>Confirmation</h4>
-              <p>Email de confirmation envoyé et données supprimées de nos systèmes</p>
-              <span class="timeline-date" id="timeline-confirmation-date"></span>
-            </div>
-          </div>
-        </div>
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="back-to-top" aria-label="Retour en haut">↑</button>
 
-        <div class="tracking-details">
-          <h4>Détails de la commande</h4>
-          <div class="details-grid">
-            <div class="detail-item">
-              <span class="detail-label">Email Spotify</span>
-              <span class="detail-value" id="result-email"></span>
-            </div>
-            <div class="detail-item">
-              <span class="detail-label">Montant payé</span>
-              <span class="detail-value" id="result-amount"></span>
-            </div>
-            <div class="detail-item">
-              <span class="detail-label">Méthode de paiement</span>
-              <span class="detail-value" id="result-payment-method"></span>
-            </div>
-            <div class="detail-item">
-              <span class="detail-label">Délai estimé</span>
-              <span class="detail-value" id="result-estimated-time"></span>
-            </div>
-          </div>
+    <!-- FOOTER -->
+    <footer class="footer">
+      <div class="container footer__inner">
+        <div class="footer-links">
+          <a href="terms.html">CGV</a>
+          <a href="privacy.html">Confidentialité</a>
+          <a href="contact.html">Contact</a>
         </div>
-
-        <div class="tracking-support">
-          <h4>Besoin d'aide ?</h4>
-          <p>Notre équipe est disponible 24/7 pour vous aider</p>
-          <a href="contact.html" class="btn btn--outline">Contacter le support</a>
-        </div>
+        <div class="footer-copy">© 2025 SpotiDeals</div>
       </div>
-    </div>
-  </section>
+    </footer>
 
-  <div class="divider divider--slant"></div>
-
-  <!-- Back to Top Button -->
-  <button id="back-to-top" class="back-to-top" aria-label="Retour en haut">
-    ↑
-  </button>
-
-  <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container footer__inner">
-      <div class="footer-links">
-        <a href="terms.html">CGV</a>
-        <a href="privacy.html">Confidentialité</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-copy">© 2025 SpotiDeals</div>
-    </div>
-  </footer>
-
-  <!-- SCRIPTS -->
-  <script src="js/main.js"></script>
-</body>
+    <!-- SCRIPTS -->
+    <script src="js/main.js"></script>
+  </body>
 </html>
-

--- a/js/main.js
+++ b/js/main.js
@@ -1,280 +1,281 @@
 // Gestion du formulaire de commande
-document.addEventListener('DOMContentLoaded', function() {
-    const orderForm = document.getElementById('order-form');
-    const orderBtn = document.getElementById('order-btn');
-    const checkboxes = document.querySelectorAll('.consent-checks input[type="checkbox"]');
+document.addEventListener('DOMContentLoaded', function () {
+  const orderForm = document.getElementById('order-form');
+  const orderBtn = document.getElementById('order-btn');
+  const checkboxes = document.querySelectorAll('.consent-checks input[type="checkbox"]');
 
-    // Fonction pour vérifier si toutes les cases sont cochées
-    function checkAllConsents() {
-        const allChecked = Array.from(checkboxes).every(checkbox => checkbox.checked);
-        orderBtn.disabled = !allChecked;
+  // Fonction pour vérifier si toutes les cases sont cochées
+  function checkAllConsents() {
+    const allChecked = Array.from(checkboxes).every((checkbox) => checkbox.checked);
+    orderBtn.disabled = !allChecked;
+  }
+
+  // Ajouter les écouteurs d'événements pour chaque checkbox
+  checkboxes.forEach((checkbox) => {
+    checkbox.addEventListener('change', checkAllConsents);
+  });
+
+  // Gestion de la soumission du formulaire
+  if (orderForm) {
+    orderForm.addEventListener('submit', function (e) {
+      e.preventDefault();
+
+      // Vérifier à nouveau les consentements avant la soumission
+      if (!Array.from(checkboxes).every((checkbox) => checkbox.checked)) {
+        alert('Veuillez accepter tous les termes avant de continuer.');
+        return;
+      }
+
+      // Récupérer les valeurs du formulaire
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+
+      // Validation basique
+      if (!email || !password) {
+        alert('Veuillez remplir tous les champs requis.');
+        return;
+      }
+
+      // Redirection vers PayPal
+      window.location.href = 'paiement.html';
+    });
+  }
+
+  // Hero → Paiement
+  const signupForm = document.getElementById('signup-form');
+  if (signupForm) {
+    signupForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const hE = document.getElementById('hero-email').value.trim();
+      const hP = document.getElementById('hero-password').value.trim();
+      if (!hE || !hP) return;
+      sessionStorage.setItem('spotifyEmail', hE);
+      sessionStorage.setItem('spotifyPassword', hP);
+      window.location.href = 'paiement.html';
+    });
+  }
+
+  // Commander → Paiement
+  const cmdE = document.getElementById('cmd-email');
+  const cmdP = document.getElementById('cmd-password');
+  const oBtn = document.getElementById('order-btn');
+
+  if (cmdE && cmdP && oBtn) {
+    function valC() {
+      oBtn.disabled = !(cmdE.checkValidity() && cmdP.value.trim());
+    }
+    cmdE.addEventListener('input', valC);
+    cmdP.addEventListener('input', valC);
+    oBtn.addEventListener('click', () => {
+      sessionStorage.setItem('spotifyEmail', cmdE.value);
+      sessionStorage.setItem('spotifyPassword', cmdP.value);
+      window.location.href = 'paiement.html';
+    });
+  }
+
+  // FAQ accordéon
+  document.querySelectorAll('.faq-item').forEach((i) => {
+    i.querySelector('h4').addEventListener('click', () => i.classList.toggle('open'));
+  });
+
+  // Cookie Consent
+  const cookieConsent = document.getElementById('cookie-consent');
+  const acceptCookies = document.getElementById('accept-cookies');
+  const rejectCookies = document.getElementById('reject-cookies');
+
+  if (cookieConsent && acceptCookies && rejectCookies) {
+    if (!localStorage.getItem('cookieConsent')) {
+      cookieConsent.style.display = 'block';
     }
 
-    // Ajouter les écouteurs d'événements pour chaque checkbox
-    checkboxes.forEach(checkbox => {
-        checkbox.addEventListener('change', checkAllConsents);
+    acceptCookies.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
+      cookieConsent.style.display = 'none';
     });
 
-    // Gestion de la soumission du formulaire
-    if (orderForm) {
-        orderForm.addEventListener('submit', function(e) {
-            e.preventDefault();
-            
-            // Vérifier à nouveau les consentements avant la soumission
-            if (!Array.from(checkboxes).every(checkbox => checkbox.checked)) {
-                alert('Veuillez accepter tous les termes avant de continuer.');
-                return;
-            }
+    rejectCookies.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'rejected');
+      cookieConsent.style.display = 'none';
+    });
+  }
 
-            // Récupérer les valeurs du formulaire
-            const email = document.getElementById('email').value;
-            const password = document.getElementById('password').value;
+  // Mobile Menu
+  const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+  const nav = document.querySelector('.nav');
 
-            // Validation basique
-            if (!email || !password) {
-                alert('Veuillez remplir tous les champs requis.');
-                return;
-            }
+  if (mobileMenuBtn && nav) {
+    mobileMenuBtn.addEventListener('click', () => {
+      nav.classList.toggle('active');
+      mobileMenuBtn.classList.toggle('active');
+    });
+  }
 
-            // Redirection vers PayPal
-            window.location.href = 'paiement.html';
-        });
-    }
+  // Back to Top Button
+  const backToTop = document.getElementById('back-to-top');
 
-    // Hero → Paiement
-    const signupForm = document.getElementById('signup-form');
-    if (signupForm) {
-        signupForm.addEventListener('submit', e => {
-            e.preventDefault();
-            const hE = document.getElementById('hero-email').value.trim();
-            const hP = document.getElementById('hero-password').value.trim();
-            if (!hE || !hP) return;
-            sessionStorage.setItem('spotifyEmail', hE);
-            sessionStorage.setItem('spotifyPassword', hP);
-            window.location.href = 'paiement.html';
-        });
-    }
-
-    // Commander → Paiement
-    const cmdE = document.getElementById('cmd-email');
-    const cmdP = document.getElementById('cmd-password');
-    const oBtn = document.getElementById('order-btn');
-    
-    if (cmdE && cmdP && oBtn) {
-        function valC() { 
-            oBtn.disabled = !(cmdE.checkValidity() && cmdP.value.trim()); 
-        }
-        cmdE.addEventListener('input', valC);
-        cmdP.addEventListener('input', valC);
-        oBtn.addEventListener('click', () => {
-            sessionStorage.setItem('spotifyEmail', cmdE.value);
-            sessionStorage.setItem('spotifyPassword', cmdP.value);
-            window.location.href = 'paiement.html';
-        });
-    }
-
-    // FAQ accordéon
-    document.querySelectorAll('.faq-item').forEach(i => {
-        i.querySelector('h4').addEventListener('click', () => i.classList.toggle('open'));
+  if (backToTop) {
+    window.addEventListener('scroll', () => {
+      if (window.pageYOffset > 300) {
+        backToTop.style.display = 'block';
+      } else {
+        backToTop.style.display = 'none';
+      }
     });
 
-    // Cookie Consent
-    const cookieConsent = document.getElementById('cookie-consent');
-    const acceptCookies = document.getElementById('accept-cookies');
-    const rejectCookies = document.getElementById('reject-cookies');
+    backToTop.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
 
-    if (cookieConsent && acceptCookies && rejectCookies) {
-        if (!localStorage.getItem('cookieConsent')) {
-            cookieConsent.style.display = 'block';
-        }
+  // Feature slider drag support
+  const featureSlider = document.querySelector('.feature-slider');
+  if (featureSlider) {
+    const sliderTrack = featureSlider.querySelector('.feature-slide-track');
+    let isDown = false;
+    let startX;
+    let scrollLeft;
 
-        acceptCookies.addEventListener('click', () => {
-            localStorage.setItem('cookieConsent', 'accepted');
-            cookieConsent.style.display = 'none';
-        });
+    const startDrag = (x) => {
+      isDown = true;
+      featureSlider.classList.add('dragging');
+      startX = x - featureSlider.offsetLeft;
+      scrollLeft = featureSlider.scrollLeft;
+    };
 
-        rejectCookies.addEventListener('click', () => {
-            localStorage.setItem('cookieConsent', 'rejected');
-            cookieConsent.style.display = 'none';
-        });
+    const endDrag = () => {
+      isDown = false;
+      featureSlider.classList.remove('dragging');
+    };
+
+    const moveDrag = (x) => {
+      if (!isDown) return;
+      const walk = x - featureSlider.offsetLeft - startX;
+      featureSlider.scrollLeft = scrollLeft - walk;
+    };
+
+    featureSlider.addEventListener('mousedown', (e) => startDrag(e.pageX));
+    featureSlider.addEventListener('touchstart', (e) => startDrag(e.touches[0].pageX), { passive: true });
+    window.addEventListener('mouseup', endDrag);
+    featureSlider.addEventListener('touchend', endDrag);
+    featureSlider.addEventListener('mousemove', (e) => moveDrag(e.pageX));
+    featureSlider.addEventListener('touchmove', (e) => moveDrag(e.touches[0].pageX), { passive: true });
+  }
+
+  // Progress bar animation
+  function updateProgressBar(step) {
+    const fill = document.getElementById('progress-bar-fill');
+    const steps = document.querySelectorAll('.step');
+    if (!fill || !steps.length) return;
+
+    let percent = 0;
+    if (step === 1) percent = 0;
+    else if (step === 2) percent = 20;
+    else if (step === 3) percent = 40;
+    else if (step === 4) percent = 60;
+    else if (step === 5) percent = 100;
+
+    fill.style.width = percent + '%';
+
+    steps.forEach((s, index) => {
+      const stepNum = index + 1;
+      s.classList.remove('active', 'completed');
+
+      if (stepNum < step) {
+        s.classList.add('completed');
+      } else if (stepNum === step) {
+        s.classList.add('active');
+      }
+    });
+  }
+  window.updateProgressBar = updateProgressBar;
+
+  // Theme Toggle
+  const themeToggle = document.getElementById('theme-toggle');
+  const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+  if (themeToggle) {
+    // Vérifier le thème sauvegardé
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      document.body.classList.toggle('light-theme', savedTheme === 'light');
+    } else {
+      document.body.classList.toggle('light-theme', !prefersDarkScheme.matches);
     }
 
-    // Mobile Menu
-    const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
-    const nav = document.querySelector('.nav');
+    // Gérer le changement de thème
+    themeToggle.addEventListener('click', () => {
+      document.body.classList.toggle('light-theme');
+      const isLight = document.body.classList.contains('light-theme');
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    });
 
-    if (mobileMenuBtn && nav) {
-        mobileMenuBtn.addEventListener('click', () => {
-            nav.classList.toggle('active');
-            mobileMenuBtn.classList.toggle('active');
-        });
-    }
+    // Écouter les changements de préférence système
+    prefersDarkScheme.addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        document.body.classList.toggle('light-theme', !e.matches);
+      }
+    });
+  }
 
-    // Back to Top Button
-    const backToTop = document.getElementById('back-to-top');
+  // Suivi de commande
+  const trackSection = document.getElementById('order-tracking');
+  if (trackSection) {
+    const trackOrderBtn = trackSection.querySelector('#track-order-btn');
+    const orderNumberInput = trackSection.querySelector('#order-number');
+    const trackingResult = trackSection.querySelector('.tracking-result');
 
-    if (backToTop) {
-        window.addEventListener('scroll', () => {
-            if (window.pageYOffset > 300) {
-                backToTop.style.display = 'block';
+    if (trackOrderBtn && orderNumberInput && trackingResult) {
+      trackOrderBtn.addEventListener('click', () => {
+        const orderNumber = orderNumberInput.value.trim();
+        if (!orderNumber) return;
+
+        // Afficher le résultat
+        trackingResult.style.display = 'block';
+
+        // Simuler les données de la commande
+        document.getElementById('result-order-number').textContent = orderNumber;
+        document.getElementById('result-order-date').textContent = new Date().toLocaleDateString();
+        document.getElementById('result-email').textContent = 'exemple@email.com';
+        document.getElementById('result-amount').textContent = '82,62$ CAD';
+        document.getElementById('result-payment-method').textContent = 'PayPal';
+        document.getElementById('result-estimated-time').textContent = '3 à 5 jours ouvrables';
+
+        // Simuler les dates de la timeline
+        const now = new Date();
+        const paymentDate = new Date(now.getTime() + 1000 * 60 * 30);
+        const verificationDate = new Date(now.getTime() + 1000 * 60 * 60);
+        document.getElementById('timeline-order-date').textContent = now.toLocaleString();
+        document.getElementById('timeline-payment-date').textContent = paymentDate.toLocaleString();
+        document.getElementById('timeline-verification-date').textContent = verificationDate.toLocaleString();
+        document.getElementById('timeline-activation-date').textContent = 'En attente';
+        document.getElementById('timeline-confirmation-date').textContent = 'En attente';
+
+        // Simuler la progression
+        let currentStep = 1;
+        const timelineItems = document.querySelectorAll('.timeline-item');
+
+        const updateTimeline = () => {
+          timelineItems.forEach((item, index) => {
+            if (index < currentStep) {
+              item.classList.add('completed');
             } else {
-                backToTop.style.display = 'none';
+              item.classList.remove('completed');
             }
-        });
-
-        backToTop.addEventListener('click', () => {
-            window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-    }
-
-    // Feature slider drag support
-    const featureSlider = document.querySelector('.feature-slider');
-    if (featureSlider) {
-        const sliderTrack = featureSlider.querySelector('.feature-slide-track');
-        let isDown = false;
-        let startX;
-        let scrollLeft;
-
-        const startDrag = (x) => {
-            isDown = true;
-            featureSlider.classList.add('dragging');
-            startX = x - featureSlider.offsetLeft;
-            scrollLeft = featureSlider.scrollLeft;
+          });
         };
 
-        const endDrag = () => {
-            isDown = false;
-            featureSlider.classList.remove('dragging');
-        };
-
-        const moveDrag = (x) => {
-            if (!isDown) return;
-            const walk = x - featureSlider.offsetLeft - startX;
-            featureSlider.scrollLeft = scrollLeft - walk;
-        };
-
-        featureSlider.addEventListener('mousedown', e => startDrag(e.pageX));
-        featureSlider.addEventListener('touchstart', e => startDrag(e.touches[0].pageX), {passive: true});
-        window.addEventListener('mouseup', endDrag);
-        featureSlider.addEventListener('touchend', endDrag);
-        featureSlider.addEventListener('mousemove', e => moveDrag(e.pageX));
-        featureSlider.addEventListener('touchmove', e => moveDrag(e.touches[0].pageX), {passive: true});
-    }
-
-    // Progress bar animation
-    function updateProgressBar(step) {
-        const fill = document.getElementById('progress-bar-fill');
-        const steps = document.querySelectorAll('.step');
-        if (!fill || !steps.length) return;
-
-        let percent = 0;
-        if (step === 1) percent = 0;
-        else if (step === 2) percent = 20;
-        else if (step === 3) percent = 40;
-        else if (step === 4) percent = 60;
-        else if (step === 5) percent = 100;
-        
-        fill.style.width = percent + '%';
-        
-        steps.forEach((s, index) => {
-            const stepNum = index + 1;
-            s.classList.remove('active', 'completed');
-
-            if (stepNum < step) {
-                s.classList.add('completed');
-            } else if (stepNum === step) {
-                s.classList.add('active');
-            }
-        });
-    }
-    window.updateProgressBar = updateProgressBar;
-
-    // Theme Toggle
-    const themeToggle = document.getElementById('theme-toggle');
-    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-    
-    if (themeToggle) {
-        // Vérifier le thème sauvegardé
-        const savedTheme = localStorage.getItem('theme');
-        if (savedTheme) {
-            document.body.classList.toggle('light-theme', savedTheme === 'light');
-        } else {
-            document.body.classList.toggle('light-theme', !prefersDarkScheme.matches);
-        }
-
-        // Gérer le changement de thème
-        themeToggle.addEventListener('click', () => {
-            document.body.classList.toggle('light-theme');
-            const isLight = document.body.classList.contains('light-theme');
-            localStorage.setItem('theme', isLight ? 'light' : 'dark');
-        });
-
-        // Écouter les changements de préférence système
-        prefersDarkScheme.addEventListener('change', (e) => {
-            if (!localStorage.getItem('theme')) {
-                document.body.classList.toggle('light-theme', !e.matches);
-            }
-        });
-    }
-
-    // Suivi de commande
-    const trackSection = document.getElementById('order-tracking');
-    if (trackSection) {
-        const trackOrderBtn = trackSection.querySelector('#track-order-btn');
-        const orderNumberInput = trackSection.querySelector('#order-number');
-        const trackingResult = trackSection.querySelector('.tracking-result');
-
-        if (trackOrderBtn && orderNumberInput && trackingResult) {
-            trackOrderBtn.addEventListener('click', () => {
-                const orderNumber = orderNumberInput.value.trim();
-                if (!orderNumber) return;
-
-            // Afficher le résultat
-            trackingResult.style.display = 'block';
-
-            // Simuler les données de la commande
-            document.getElementById('result-order-number').textContent = orderNumber;
-            document.getElementById('result-order-date').textContent = new Date().toLocaleDateString();
-            document.getElementById('result-email').textContent = 'exemple@email.com';
-            document.getElementById('result-amount').textContent = '82,62$ CAD';
-            document.getElementById('result-payment-method').textContent = 'PayPal';
-            document.getElementById('result-estimated-time').textContent = '3 à 5 jours ouvrables';
-
-            // Simuler les dates de la timeline
-            const now = new Date();
-            document.getElementById('timeline-order-date').textContent = now.toLocaleString();
-            document.getElementById('timeline-payment-date').textContent = new Date(now.getTime() + 1000 * 60 * 30).toLocaleString();
-            document.getElementById('timeline-verification-date').textContent = new Date(now.getTime() + 1000 * 60 * 60).toLocaleString();
-            document.getElementById('timeline-activation-date').textContent = 'En attente';
-            document.getElementById('timeline-confirmation-date').textContent = 'En attente';
-
-            // Simuler la progression
-            let currentStep = 1;
-            const timelineItems = document.querySelectorAll('.timeline-item');
-            
-            const updateTimeline = () => {
-                timelineItems.forEach((item, index) => {
-                    if (index < currentStep) {
-                        item.classList.add('completed');
-                    } else {
-                        item.classList.remove('completed');
-                    }
-                });
-            };
-
-            // Simuler les mises à jour
-            const simulateProgress = () => {
-                if (currentStep < 3) {
-                    currentStep++;
-                    updateTimeline();
-                    setTimeout(simulateProgress, 3000);
-                }
-            };
-
+        // Simuler les mises à jour
+        const simulateProgress = () => {
+          if (currentStep < 3) {
+            currentStep++;
             updateTimeline();
             setTimeout(simulateProgress, 3000);
-        });
-        }
-    }
-});
+          }
+        };
 
+        updateTimeline();
+        setTimeout(simulateProgress, 3000);
+      });
+    }
+  }
+});

--- a/paiement.html
+++ b/paiement.html
@@ -1,75 +1,81 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>SpotiDeals – Paiement Spotify Premium 12 mois</title>
-  <meta name="description" content="Réglez en un clic votre Pack Activation Spotify Premium 12 mois en toute sécurité via PayPal. Traitement rapide et garantie incluse.">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="css/style.css">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SpotiDeals – Paiement Spotify Premium 12 mois</title>
+    <meta
+      name="description"
+      content="Réglez votre Pack Spotify Premium 12 mois via PayPal. Traitement rapide garanti."
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="container header__inner">
+        <a href="index.html" class="logo">SpotiDeals</a>
+        <nav class="nav">
+          <a href="index.html#features">Fonctionnalités</a>
+          <a href="index.html#pricing">Tarifs</a>
+          <a href="index.html#how">Comment ça marche</a>
+          <a href="index.html#faq">FAQ</a>
+        </nav>
+        <a href="index.html#commande" class="btn btn--sm">Commander</a>
+      </div>
+    </header>
 
-  <!-- HEADER -->
-  <header class="header">
-    <div class="container header__inner">
-      <a href="index.html" class="logo">SpotiDeals</a>
-      <nav class="nav">
-        <a href="index.html#features">Fonctionnalités</a>
-        <a href="index.html#pricing">Tarifs</a>
-        <a href="index.html#how">Comment ça marche</a>
-        <a href="index.html#faq">FAQ</a>
-      </nav>
-      <a href="index.html#commande" class="btn btn--sm">Commander</a>
-    </div>
-  </header>
+    <!-- MAIN CONTENT -->
+    <main class="container card">
+      <h1>Paiement sécurisé</h1>
+      <div id="paypal-button-container"></div>
+      <a href="index.html" class="btn">← Retour à l'accueil</a>
+    </main>
 
-  <!-- MAIN CONTENT -->
-  <main class="container card">
-    <h1>Paiement sécurisé</h1>
-    <div id="paypal-button-container"></div>
-    <a href="index.html" class="btn">← Retour à l'accueil</a>
-  </main>
+    <!-- FOOTER -->
+    <footer class="footer">
+      <div class="container footer__inner">
+        <div>© 2025 SpotiDeals</div>
+        <nav>
+          <a href="terms.html">CGV</a>
+          <a href="privacy.html">Confidentialité</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </footer>
 
-  <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container footer__inner">
-      <div>© 2025 SpotiDeals</div>
-      <nav>
-        <a href="terms.html">CGV</a>
-        <a href="privacy.html">Confidentialité</a>
-        <a href="contact.html">Contact</a>
-      </nav>
-    </div>
-  </footer>
+    <!-- prettier-ignore -->
+    <!-- PayPal SDK -->
+    <script src="https://www.paypal.com/sdk/js?client-id=AW-bLBrtEPaB0FTD-Oa4rQ1gbQBNLkkqSsAtGh968nfbb-HA_iZh-Cptg_1U
+zbE9GYagkCPtHFEUosfm&currency=CAD"></script>
 
-  <!-- PayPal SDK -->
-  <script src="https://www.paypal.com/sdk/js?client-id=AW-bLBrtEPaB0FTD-Oa4rQ1gbQBNLkkqSsAtGh968nfbb-HA_iZh-Cptg_1UzbE9GYagkCPtHFEUosfm&currency=CAD"></script>
-  
-  <!-- Script de paiement -->
-  <script>
-    // Générer un numéro de commande unique
-    function generateOrderID() {
-      const timestamp = Date.now().toString();
-      const random = Math.floor(Math.random() * 1000).toString().padStart(3, '0');
-      return `SPD-${timestamp}-${random}`;
-    }
+    <!-- Script de paiement -->
+    <script>
+      // Générer un numéro de commande unique
+      function generateOrderID() {
+        const timestamp = Date.now().toString();
+        const random = Math.floor(Math.random() * 1000)
+          .toString()
+          .padStart(3, '0');
+        return `SPD-${timestamp}-${random}`;
+      }
 
-    // Envoyer l'email de confirmation
-    async function sendConfirmationEmail(email, orderID) {
-      try {
-        const response = await fetch('https://formspree.io/f/xanorewp', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            email: email,
-            orderID: orderID,
-            subject: 'Confirmation de votre commande SpotiDeals',
-            _template: 'table',
-            _subject: 'Nouvelle commande SpotiDeals - ' + orderID,
-            _format: 'html',
-            _autoresponse: `
+      // Envoyer l'email de confirmation
+      async function sendConfirmationEmail(email, orderID) {
+        try {
+          const response = await fetch('https://formspree.io/f/xanorewp', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              email: email,
+              orderID: orderID,
+              subject: 'Confirmation de votre commande SpotiDeals',
+              _template: 'table',
+              _subject: 'Nouvelle commande SpotiDeals - ' + orderID,
+              _format: 'html',
+              _autoresponse: `
               <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
                 <div style="text-align: center; margin-bottom: 30px;">
                   <img src="https://spotideals.com/images/logo.png" alt="SpotiDeals Logo" style="max-width: 200px;">
@@ -79,13 +85,22 @@
                 
                 <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 30px;">
                   <p style="margin: 0; font-size: 16px;">Bonjour,</p>
-                  <p style="margin: 10px 0; font-size: 16px;">Nous avons bien reçu votre commande pour l'activation de Spotify Premium.</p>
+                  <!-- prettier-ignore -->
+                  <p style="margin: 10px 0; font-size: 16px;">
+                    Nous avons bien reçu votre commande pour l'activation de Spotify Premium.
+                  </p>
                   
                   <div style="margin: 20px 0; padding: 15px; background-color: white; border-radius: 5px;">
-                    <p style="margin: 0; font-weight: bold;">Numéro de commande : <span style="color: #1DB954;">${orderID}</span></p>
+                    <!-- prettier-ignore -->
+                    <p style="margin: 0; font-weight: bold;">
+                      Numéro de commande : <span style="color: #1DB954;">${orderID}</span>
+                    </p>
                   </div>
                   
-                  <p style="margin: 10px 0; font-size: 16px;">Votre commande sera traitée sous 3 à 5 jours ouvrables.</p>
+                  <!-- prettier-ignore -->
+                  <p style="margin: 10px 0; font-size: 16px;">
+                    Votre commande sera traitée sous 3 à 5 jours ouvrables.
+                  </p>
                 </div>
                 
                 <div style="margin-bottom: 30px;">
@@ -99,8 +114,26 @@
                 
                 <div style="margin-bottom: 30px;">
                   <h2 style="color: #333; font-size: 18px;">Suivi de commande :</h2>
-                  <p style="color: #666;">Vous pouvez suivre l'état de votre commande en utilisant votre numéro de commande sur notre page de suivi :</p>
-                  <a href="https://spotideals.com/tracking.html" style="display: inline-block; background-color: #1DB954; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; margin-top: 10px;">Suivre ma commande</a>
+                  <!-- prettier-ignore -->
+                    <p style="color: #666;">
+                      Vous pouvez suivre l'état de votre commande en utilisant
+                      votre numéro sur notre page de suivi :
+                    </p>
+                  <!-- prettier-ignore -->
+                  <a
+                    href="https://spotideals.com/tracking.html"
+                    style="
+                      display: inline-block;
+                      background-color: #1DB954;
+                      color: white;
+                      padding: 12px 25px;
+                      text-decoration: none;
+                      border-radius: 5px;
+                      margin-top: 10px;
+                    "
+                  >
+                    Suivre ma commande
+                  </a>
                 </div>
                 
                 <div style="text-align: center; color: #666; font-size: 14px; margin-top: 40px;">
@@ -108,55 +141,71 @@
                   <p>Email : contact@spotideals.com</p>
                 </div>
                 
-                <div style="text-align: center; color: #999; font-size: 12px; margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee;">
+                <!-- prettier-ignore -->
+                <div
+                  style="
+                    text-align: center;
+                    color: #999;
+                    font-size: 12px;
+                    margin-top: 40px;
+                    padding-top: 20px;
+                    border-top: 1px solid #eee;
+                  "
+                >
                   <p>© 2025 SpotiDeals. Tous droits réservés.</p>
                 </div>
               </div>
-            `
-          })
-        });
+            `,
+            }),
+          });
 
-        if (!response.ok) {
-          throw new Error('Erreur lors de l\'envoi de l\'email');
+          if (!response.ok) {
+            throw new Error("Erreur lors de l'envoi de l'email");
+          }
+
+          return true;
+        } catch (error) {
+          console.error('Erreur:', error);
+          return false;
         }
-
-        return true;
-      } catch (error) {
-        console.error('Erreur:', error);
-        return false;
       }
-    }
 
-    // Configuration PayPal
-    paypal.Buttons({
-      createOrder: function(data, actions) {
-        return actions.order.create({
-          purchase_units: [{
-            amount: {
-              value: '82.62'
+      // Configuration PayPal
+      paypal
+        .Buttons({
+          createOrder: function (data, actions) {
+            return actions.order.create({
+              purchase_units: [
+                {
+                  amount: {
+                    value: '82.62',
+                  },
+                },
+              ],
+            });
+          },
+          onApprove: async function (data, actions) {
+            const order = await actions.order.capture();
+            const email = sessionStorage.getItem('spotifyEmail');
+            const id = generateOrderID();
+
+            // Envoyer l'email de confirmation
+            const emailSent = await sendConfirmationEmail(email, id);
+
+            if (emailSent) {
+              // Afficher le message de succès
+              alert(
+                '✅ Paiement reçu ! Un email de confirmation avec votre numéro de commande a été envoyé à ' + email,
+              );
+
+              // Rediriger vers la page de suivi
+              window.location.href = 'index.html#order-tracking';
+            } else {
+              alert("⚠️ Paiement reçu mais erreur lors de l'envoi de l'email. Veuillez contacter le support.");
             }
-          }]
-        });
-      },
-      onApprove: async function(data, actions) {
-        const order = await actions.order.capture();
-        const email = sessionStorage.getItem('spotifyEmail');
-        const id = generateOrderID();
-        
-        // Envoyer l'email de confirmation
-        const emailSent = await sendConfirmationEmail(email, id);
-        
-        if (emailSent) {
-          // Afficher le message de succès
-          alert('✅ Paiement reçu ! Un email de confirmation avec votre numéro de commande a été envoyé à ' + email);
-          
-          // Rediriger vers la page de suivi
-          window.location.href = 'index.html#order-tracking';
-        } else {
-          alert('⚠️ Paiement reçu mais erreur lors de l\'envoi de l\'email. Veuillez contacter le support.');
-        }
-      }
-    }).render('#paypal-button-container');
-  </script>
-</body>
+          },
+        })
+        .render('#paypal-button-container');
+    </script>
+  </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,49 +1,51 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>SpotiDeals – Politique de Confidentialité</title>
-  <meta name="description" content="Découvrez comment SpotiDeals protège vos données personnelles lors de l’activation de votre compte Spotify Premium.">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="css/style.css">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SpotiDeals – Politique de Confidentialité</title>
+    <meta
+      name="description"
+      content="Découvrez comment SpotiDeals protège vos données personnelles
+      lors de l’activation de votre compte Spotify Premium."
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="container header__inner">
+        <a href="index.html" class="logo">SpotiDeals</a>
+        <nav class="nav">
+          <a href="index.html#features">Fonctionnalités</a>
+          <a href="index.html#pricing">Tarifs</a>
+          <a href="index.html#how">Comment ça marche</a>
+          <a href="index.html#faq">FAQ</a>
+        </nav>
+        <a href="index.html#commande" class="btn btn--sm">Commander</a>
+      </div>
+    </header>
 
-  <!-- HEADER -->
-  <header class="header">
-    <div class="container header__inner">
-      <a href="index.html" class="logo">SpotiDeals</a>
-      <nav class="nav">
-        <a href="index.html#features">Fonctionnalités</a>
-        <a href="index.html#pricing">Tarifs</a>
-        <a href="index.html#how">Comment ça marche</a>
-        <a href="index.html#faq">FAQ</a>
-      </nav>
-      <a href="index.html#commande" class="btn btn--sm">Commander</a>
-    </div>
-  </header>
+    <!-- MAIN CONTENT -->
+    <main class="container card">
+      <h1>Politique de Confidentialité</h1>
+      <ul>
+        <li>Vos données (e-mail, username) sont utilisées uniquement pour traiter votre commande.</li>
+        <li>Le mot de passe n’est pas collecté sur le site ; vous l’enverrez ensuite par e-mail sécurisé.</li>
+        <li>Vous pouvez demander la suppression de vos données à tout moment.</li>
+      </ul>
+    </main>
 
-  <!-- MAIN CONTENT -->
-  <main class="container card">
-    <h1>Politique de Confidentialité</h1>
-    <ul>
-      <li>Vos données (e-mail, username) sont utilisées uniquement pour traiter votre commande.</li>
-      <li>Le mot de passe n’est pas collecté sur le site ; vous l’enverrez ensuite par e-mail sécurisé.</li>
-      <li>Vous pouvez demander la suppression de vos données à tout moment.</li>
-    </ul>
-  </main>
-
-  <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container footer__inner">
-      <div>© 2025 SpotiDeals</div>
-      <nav>
-        <a href="terms.html">CGV</a>
-        <a href="privacy.html">Confidentialité</a>
-        <a href="contact.html">Contact</a>
-      </nav>
-    </div>
-  </footer>
-
-</body>
+    <!-- FOOTER -->
+    <footer class="footer">
+      <div class="container footer__inner">
+        <div>© 2025 SpotiDeals</div>
+        <nav>
+          <a href="terms.html">CGV</a>
+          <a href="privacy.html">Confidentialité</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -1,51 +1,53 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>SpotiDeals – Conditions Générales de Vente</title>
-  <meta name="description" content="Consultez les conditions générales de vente de SpotiDeals pour l'activation de votre abonnement Spotify Premium 12 mois.">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="css/style.css">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SpotiDeals – Conditions Générales de Vente</title>
+    <meta
+      name="description"
+      content="Consultez les conditions générales de vente de SpotiDeals pour l'activation
+     de Spotify Premium."
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="container header__inner">
+        <a href="index.html" class="logo">SpotiDeals</a>
+        <nav class="nav">
+          <a href="index.html#features">Fonctionnalités</a>
+          <a href="index.html#pricing">Tarifs</a>
+          <a href="index.html#how">Comment ça marche</a>
+          <a href="index.html#faq">FAQ</a>
+        </nav>
+        <a href="index.html#commande" class="btn btn--sm">Commander</a>
+      </div>
+    </header>
 
-  <!-- HEADER -->
-  <header class="header">
-    <div class="container header__inner">
-      <a href="index.html" class="logo">SpotiDeals</a>
-      <nav class="nav">
-        <a href="index.html#features">Fonctionnalités</a>
-        <a href="index.html#pricing">Tarifs</a>
-        <a href="index.html#how">Comment ça marche</a>
-        <a href="index.html#faq">FAQ</a>
-      </nav>
-      <a href="index.html#commande" class="btn btn--sm">Commander</a>
-    </div>
-  </header>
+    <!-- MAIN CONTENT -->
+    <main class="container card">
+      <h1>Conditions Générales de Vente</h1>
+      <ul>
+        <li>Prestation de service : activation de votre compte Spotify Premium individuel.</li>
+        <li>Délai de traitement : 3 à 5 jours ouvrables après paiement.</li>
+        <li>Activation : jusqu'à 24 heures après traitement.</li>
+        <li>Support inclus pendant 7 jours après activation.</li>
+        <li>Aucun remboursement si l'activation est effectuée.</li>
+      </ul>
+    </main>
 
-  <!-- MAIN CONTENT -->
-  <main class="container card">
-    <h1>Conditions Générales de Vente</h1>
-    <ul>
-      <li>Prestation de service : activation de votre compte Spotify Premium individuel.</li>
-      <li>Délai de traitement : 3 à 5 jours ouvrables après paiement.</li>
-      <li>Activation : jusqu'à 24 heures après traitement.</li>
-      <li>Support inclus pendant 7 jours après activation.</li>
-      <li>Aucun remboursement si l'activation est effectuée.</li>
-    </ul>
-  </main>
-
-  <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container footer__inner">
-      <div>© 2025 SpotiDeals</div>
-      <nav>
-        <a href="terms.html">CGV</a>
-        <a href="privacy.html">Confidentialité</a>
-        <a href="contact.html">Contact</a>
-      </nav>
-    </div>
-  </footer>
-
-</body>
+    <!-- FOOTER -->
+    <footer class="footer">
+      <div class="container footer__inner">
+        <div>© 2025 SpotiDeals</div>
+        <nav>
+          <a href="terms.html">CGV</a>
+          <a href="privacy.html">Confidentialité</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/tracking.html
+++ b/tracking.html
@@ -1,294 +1,300 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8">
-  <title>SpotiDeals – Suivi de commande</title>
-  <meta name="description" content="Suivez l'état de votre commande SpotiDeals en temps réel. Entrez votre numéro de commande pour voir son statut.">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="css/style.css">
-  <style>
-    .tracking-form {
-      max-width: 500px;
-      margin: 2rem auto;
-      padding: 2rem;
-      background: white;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    }
-
-    .tracking-form input {
-      width: 100%;
-      padding: 12px;
-      margin: 8px 0;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 16px;
-    }
-
-    .tracking-result {
-      margin-top: 2rem;
-      padding: 1.5rem;
-      border-radius: 8px;
-      display: none;
-    }
-
-    .tracking-result.active {
-      display: block;
-    }
-
-    .status-badge {
-      display: inline-block;
-      padding: 6px 12px;
-      border-radius: 20px;
-      font-size: 14px;
-      font-weight: 500;
-      margin: 8px 0;
-    }
-
-    .status-pending {
-      background: #fff3cd;
-      color: #856404;
-    }
-
-    .status-processing {
-      background: #cce5ff;
-      color: #004085;
-    }
-
-    .status-completed {
-      background: #d4edda;
-      color: #155724;
-    }
-
-    .timeline {
-      margin: 2rem 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .timeline-item {
-      position: relative;
-      padding-left: 30px;
-      margin-bottom: 1.5rem;
-    }
-
-    .timeline-item::before {
-      content: '';
-      position: absolute;
-      left: 0;
-      top: 0;
-      bottom: 0;
-      width: 2px;
-      background: #e9ecef;
-    }
-
-    .timeline-item::after {
-      content: '';
-      position: absolute;
-      left: -4px;
-      top: 0;
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      background: #1DB954;
-    }
-
-    .timeline-item.completed::after {
-      background: #1DB954;
-    }
-
-    .timeline-item.pending::after {
-      background: #ffc107;
-    }
-
-    .timeline-item.future::after {
-      background: #e9ecef;
-    }
-
-    .timeline-date {
-      font-size: 14px;
-      color: #6c757d;
-      margin-bottom: 4px;
-    }
-
-    .timeline-title {
-      font-weight: 500;
-      margin-bottom: 4px;
-    }
-
-    .timeline-description {
-      color: #6c757d;
-      font-size: 14px;
-    }
-  </style>
-</head>
-<body>
-  <!-- HEADER -->
-  <header class="header">
-    <div class="container header__inner">
-      <a href="index.html" class="logo">SpotiDeals</a>
-      <nav class="nav">
-        <a href="index.html#features">Fonctionnalités</a>
-        <a href="index.html#pricing">Tarifs</a>
-        <a href="index.html#how">Comment ça marche</a>
-        <a href="index.html#faq">FAQ</a>
-      </nav>
-      <a href="index.html#commande" class="btn btn--sm">Commander</a>
-    </div>
-  </header>
-
-  <!-- MAIN CONTENT -->
-  <main class="container">
-    <div class="tracking-container">
-      <h1>Suivi de commande</h1>
-      <p>Entrez votre numéro de commande pour suivre son statut</p>
-      
-      <form onsubmit="return checkOrder(event)" class="tracking-form">
-        <div class="form-group">
-          <input type="text" id="orderNumber" placeholder="Entrez votre numéro de commande" required>
-        </div>
-        <button type="submit" class="btn btn-primary">Suivre ma commande</button>
-      </form>
-
-      <div id="trackingResult" class="tracking-result">
-        <div class="status-badge" id="statusBadge"></div>
-        <h2>Détails de la commande</h2>
-        <div id="orderDetails"></div>
-        
-        <ul class="timeline" id="orderTimeline">
-          <!-- Timeline items will be added here -->
-        </ul>
-      </div>
-    </div>
-  </main>
-
-  <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container footer__inner">
-      <div>© 2025 SpotiDeals</div>
-      <nav>
-        <a href="terms.html">CGV</a>
-        <a href="privacy.html">Confidentialité</a>
-        <a href="contact.html">Contact</a>
-      </nav>
-    </div>
-  </footer>
-
-  <script>
-    const API_URL = 'https://script.google.com/macros/s/AKfycbxEmJdgcerK1ENvsy8IvSnAZDJ6p4fr9hfO87haKbKrVXZaRf2Z3wnRzyQSDl527VtW/exec';
-
-    async function checkOrder(event) {
-      event.preventDefault();
-      const orderNumber = document.getElementById('orderNumber').value;
-      const resultDiv = document.getElementById('trackingResult');
-      const statusBadge = document.getElementById('statusBadge');
-      const orderDetails = document.getElementById('orderDetails');
-      const timeline = document.getElementById('orderTimeline');
-
-      try {
-        const res = await fetch(`${API_URL}?orderID=${orderNumber}`);
-        const data = await res.json();
-
-        if (data.error) {
-          alert("Commande introuvable");
-          return false;
-        }
-
-        resultDiv.classList.add('active');
-        let statusText = 'En attente de traitement';
-        let statusClass = 'status-pending';
-        if (data.status === 'processing') {
-          statusText = 'En cours de traitement';
-          statusClass = 'status-processing';
-        } else if (data.status === 'completed') {
-          statusText = 'Commande complétée';
-          statusClass = 'status-completed';
-        }
-        statusBadge.textContent = statusText;
-        statusBadge.className = `status-badge ${statusClass}`;
-        orderDetails.textContent = '';
-
-        const idP = document.createElement('p');
-        const idStrong = document.createElement('strong');
-        idStrong.textContent = 'Numéro de commande:';
-        idP.appendChild(idStrong);
-        idP.appendChild(document.createTextNode(' ' + data.orderID));
-        orderDetails.appendChild(idP);
-
-        const dateP = document.createElement('p');
-        const dateStrong = document.createElement('strong');
-        dateStrong.textContent = 'Date de commande:';
-        dateP.appendChild(dateStrong);
-        dateP.appendChild(document.createTextNode(' ' + new Date(data.date).toLocaleDateString()));
-        orderDetails.appendChild(dateP);
-
-        const emailP = document.createElement('p');
-        const emailStrong = document.createElement('strong');
-        emailStrong.textContent = 'Email:';
-        emailP.appendChild(emailStrong);
-        emailP.appendChild(document.createTextNode(' ' + data.email));
-        orderDetails.appendChild(emailP);
-
-        if (data.notes) {
-          const notesP = document.createElement('p');
-          const notesStrong = document.createElement('strong');
-          notesStrong.textContent = 'Notes:';
-          notesP.appendChild(notesStrong);
-          notesP.appendChild(document.createTextNode(' ' + data.notes));
-          orderDetails.appendChild(notesP);
-        }
-        
-        const orderDate = new Date(data.date);
-        timeline.textContent = '';
-
-        const steps = [
-          {
-            cls: 'completed',
-            date: orderDate,
-            title: 'Commande reçue',
-            desc: 'Votre commande a été enregistrée avec succès'
-          },
-          {
-            cls: data.status !== 'pending' ? 'completed' : 'pending',
-            date: new Date(orderDate.getTime() + 3 * 24 * 60 * 60 * 1000),
-            title: 'Vérification des informations',
-            desc: 'Nous vérifions vos informations de compte'
-          },
-          {
-            cls: data.status === 'completed' ? 'completed' : 'future',
-            date: new Date(orderDate.getTime() + 5 * 24 * 60 * 60 * 1000),
-            title: 'Activation du compte',
-            desc: 'Votre compte Spotify Premium est activé'
-          }
-        ];
-
-        steps.forEach(step => {
-          const li = document.createElement('li');
-          li.className = `timeline-item ${step.cls}`;
-
-          const dateDiv = document.createElement('div');
-          dateDiv.className = 'timeline-date';
-          dateDiv.textContent = step.date.toLocaleDateString();
-          li.appendChild(dateDiv);
-
-          const titleDiv = document.createElement('div');
-          titleDiv.className = 'timeline-title';
-          titleDiv.textContent = step.title;
-          li.appendChild(titleDiv);
-
-          const descDiv = document.createElement('div');
-          descDiv.className = 'timeline-description';
-          descDiv.textContent = step.desc;
-          li.appendChild(descDiv);
-
-          timeline.appendChild(li);
-        });
-      } catch (error) {
-        console.error("Erreur:", error);
-        alert("Erreur lors de la vérification de la commande.");
+  <head>
+    <meta charset="UTF-8" />
+    <title>SpotiDeals – Suivi de commande</title>
+    <meta
+      name="description"
+      content="Suivez l'état de votre commande SpotiDeals en temps réel
+    grâce à votre numéro de commande."
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="css/style.css" />
+    <style>
+      .tracking-form {
+        max-width: 500px;
+        margin: 2rem auto;
+        padding: 2rem;
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
       }
-      return false;
-    }
-  </script>
-</body>
-</html> 
+
+      .tracking-form input {
+        width: 100%;
+        padding: 12px;
+        margin: 8px 0;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        font-size: 16px;
+      }
+
+      .tracking-result {
+        margin-top: 2rem;
+        padding: 1.5rem;
+        border-radius: 8px;
+        display: none;
+      }
+
+      .tracking-result.active {
+        display: block;
+      }
+
+      .status-badge {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 20px;
+        font-size: 14px;
+        font-weight: 500;
+        margin: 8px 0;
+      }
+
+      .status-pending {
+        background: #fff3cd;
+        color: #856404;
+      }
+
+      .status-processing {
+        background: #cce5ff;
+        color: #004085;
+      }
+
+      .status-completed {
+        background: #d4edda;
+        color: #155724;
+      }
+
+      .timeline {
+        margin: 2rem 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .timeline-item {
+        position: relative;
+        padding-left: 30px;
+        margin-bottom: 1.5rem;
+      }
+
+      .timeline-item::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 2px;
+        background: #e9ecef;
+      }
+
+      .timeline-item::after {
+        content: '';
+        position: absolute;
+        left: -4px;
+        top: 0;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #1db954;
+      }
+
+      .timeline-item.completed::after {
+        background: #1db954;
+      }
+
+      .timeline-item.pending::after {
+        background: #ffc107;
+      }
+
+      .timeline-item.future::after {
+        background: #e9ecef;
+      }
+
+      .timeline-date {
+        font-size: 14px;
+        color: #6c757d;
+        margin-bottom: 4px;
+      }
+
+      .timeline-title {
+        font-weight: 500;
+        margin-bottom: 4px;
+      }
+
+      .timeline-description {
+        color: #6c757d;
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="container header__inner">
+        <a href="index.html" class="logo">SpotiDeals</a>
+        <nav class="nav">
+          <a href="index.html#features">Fonctionnalités</a>
+          <a href="index.html#pricing">Tarifs</a>
+          <a href="index.html#how">Comment ça marche</a>
+          <a href="index.html#faq">FAQ</a>
+        </nav>
+        <a href="index.html#commande" class="btn btn--sm">Commander</a>
+      </div>
+    </header>
+
+    <!-- MAIN CONTENT -->
+    <main class="container">
+      <div class="tracking-container">
+        <h1>Suivi de commande</h1>
+        <p>Entrez votre numéro de commande pour suivre son statut</p>
+
+        <form onsubmit="return checkOrder(event)" class="tracking-form">
+          <div class="form-group">
+            <input type="text" id="orderNumber" placeholder="Entrez votre numéro de commande" required />
+          </div>
+          <button type="submit" class="btn btn-primary">Suivre ma commande</button>
+        </form>
+
+        <div id="trackingResult" class="tracking-result">
+          <div class="status-badge" id="statusBadge"></div>
+          <h2>Détails de la commande</h2>
+          <div id="orderDetails"></div>
+
+          <ul class="timeline" id="orderTimeline">
+            <!-- Timeline items will be added here -->
+          </ul>
+        </div>
+      </div>
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="footer">
+      <div class="container footer__inner">
+        <div>© 2025 SpotiDeals</div>
+        <nav>
+          <a href="terms.html">CGV</a>
+          <a href="privacy.html">Confidentialité</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </footer>
+
+    <script>
+      const API_URL =
+        'https://script.google.com/macros/s/' +
+        'AKfycbxEmJdgcerK1ENvsy8IvSnAZDJ6p4fr9hfO87haKbKrVXZaRf2Z3wnRzyQSDl527VtW/exec';
+
+      async function checkOrder(event) {
+        event.preventDefault();
+        const orderNumber = document.getElementById('orderNumber').value;
+        const resultDiv = document.getElementById('trackingResult');
+        const statusBadge = document.getElementById('statusBadge');
+        const orderDetails = document.getElementById('orderDetails');
+        const timeline = document.getElementById('orderTimeline');
+
+        try {
+          const res = await fetch(`${API_URL}?orderID=${orderNumber}`);
+          const data = await res.json();
+
+          if (data.error) {
+            alert('Commande introuvable');
+            return false;
+          }
+
+          resultDiv.classList.add('active');
+          let statusText = 'En attente de traitement';
+          let statusClass = 'status-pending';
+          if (data.status === 'processing') {
+            statusText = 'En cours de traitement';
+            statusClass = 'status-processing';
+          } else if (data.status === 'completed') {
+            statusText = 'Commande complétée';
+            statusClass = 'status-completed';
+          }
+          statusBadge.textContent = statusText;
+          statusBadge.className = `status-badge ${statusClass}`;
+          orderDetails.textContent = '';
+
+          const idP = document.createElement('p');
+          const idStrong = document.createElement('strong');
+          idStrong.textContent = 'Numéro de commande:';
+          idP.appendChild(idStrong);
+          idP.appendChild(document.createTextNode(' ' + data.orderID));
+          orderDetails.appendChild(idP);
+
+          const dateP = document.createElement('p');
+          const dateStrong = document.createElement('strong');
+          dateStrong.textContent = 'Date de commande:';
+          dateP.appendChild(dateStrong);
+          dateP.appendChild(document.createTextNode(' ' + new Date(data.date).toLocaleDateString()));
+          orderDetails.appendChild(dateP);
+
+          const emailP = document.createElement('p');
+          const emailStrong = document.createElement('strong');
+          emailStrong.textContent = 'Email:';
+          emailP.appendChild(emailStrong);
+          emailP.appendChild(document.createTextNode(' ' + data.email));
+          orderDetails.appendChild(emailP);
+
+          if (data.notes) {
+            const notesP = document.createElement('p');
+            const notesStrong = document.createElement('strong');
+            notesStrong.textContent = 'Notes:';
+            notesP.appendChild(notesStrong);
+            notesP.appendChild(document.createTextNode(' ' + data.notes));
+            orderDetails.appendChild(notesP);
+          }
+
+          const orderDate = new Date(data.date);
+          timeline.textContent = '';
+
+          const steps = [
+            {
+              cls: 'completed',
+              date: orderDate,
+              title: 'Commande reçue',
+              desc: 'Votre commande a été enregistrée avec succès',
+            },
+            {
+              cls: data.status !== 'pending' ? 'completed' : 'pending',
+              date: new Date(orderDate.getTime() + 3 * 24 * 60 * 60 * 1000),
+              title: 'Vérification des informations',
+              desc: 'Nous vérifions vos informations de compte',
+            },
+            {
+              cls: data.status === 'completed' ? 'completed' : 'future',
+              date: new Date(orderDate.getTime() + 5 * 24 * 60 * 60 * 1000),
+              title: 'Activation du compte',
+              desc: 'Votre compte Spotify Premium est activé',
+            },
+          ];
+
+          steps.forEach((step) => {
+            const li = document.createElement('li');
+            li.className = `timeline-item ${step.cls}`;
+
+            const dateDiv = document.createElement('div');
+            dateDiv.className = 'timeline-date';
+            dateDiv.textContent = step.date.toLocaleDateString();
+            li.appendChild(dateDiv);
+
+            const titleDiv = document.createElement('div');
+            titleDiv.className = 'timeline-title';
+            titleDiv.textContent = step.title;
+            li.appendChild(titleDiv);
+
+            const descDiv = document.createElement('div');
+            descDiv.className = 'timeline-description';
+            descDiv.textContent = step.desc;
+            li.appendChild(descDiv);
+
+            timeline.appendChild(li);
+          });
+        } catch (error) {
+          console.error('Erreur:', error);
+          alert('Erreur lors de la vérification de la commande.');
+        }
+        return false;
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- enforce line length in JS/HTML
- split paypal sdk tag and long paragraphs for readability
- shorten meta descriptions
- assign timeline dates to variables for clarity

## Testing
- `npx prettier --write "*.html" "js/*.js"`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684121174538832eaf86cba578a5b3e9